### PR TITLE
Set up Linux gcc and Windows MSVC CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,3 +16,14 @@ jobs:
         cd src
         gcc -DTEST build.c -o build
         ./build
+
+  windows-msvc:
+    runs-on: windows-2022
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ilammy/msvc-dev-cmd@v1.13.0
+    - name: Build and test
+      run: |
+        cd src
+        cl build.c -DTEST
+        .\build.exe

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,18 @@
+name: ci
+
+on: [push, pull_request, workflow_dispatch]
+
+permissions:
+  contents: read
+
+jobs:
+  linux-gcc:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v4
+    - run: gcc --version
+    - name: Build and test
+      run: |
+        cd src
+        gcc -DTEST build.c -o build
+        ./build


### PR DESCRIPTION
The way I set it up is that `on: [push, pull_request, workflow_dispatch]` makes it run on push, PR, or you can trigger runs manually under the Actions tab on GitHub.

There is a bunch of tests failing, but since `build` doesn't return 1, the CI system doesn't find out about that.

See https://github.com/robinlinden/cake/actions/runs/8180353564 for a run of this.

See: #137 