### PR TITLE
Fixed typo in link to manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ cake source.c
 
 this will output *./out/source.c*
 
-See [Manual](manual.html)
+See [Manual](manual.md)
 
 
 


### PR DESCRIPTION
Manual link was broken. Fixed now