### PR TITLE
Update ci.yaml with Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,17 @@ jobs:
         gcc -DTEST build.c -o build
         ./build
 
+  linux-gcc-ubuntu-prev:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v4
+    - run: gcc --version
+    - name: Build
+      run: |
+        cd src
+        gcc build.c -o build
+        ./build
+
   windows-msvc:
     runs-on: windows-2022
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,17 @@ jobs:
         gcc build.c -o build
         ./build
 
+  linux-gcc-ubuntu-prevp:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v4
+    - run: gcc --version
+    - name: Build
+      run: |
+        cd src
+        gcc build.c -o build
+        ./build
+
   windows-msvc:
     runs-on: windows-2022
     steps:


### PR DESCRIPTION
Here I've added a build on Ubuntu-20-04 were there is several warnings the somehow doesn't appear on Ubuntu-22.04.