### PR TITLE
Add missing limits.h include to fix undeclared INT_MAX

### DIFF
--- a/src/visit_il.c
+++ b/src/visit_il.c
@@ -24,6 +24,7 @@ static char mon[][4] = {
 #include <stdio.h>
 #include <assert.h>
 #include <stdint.h>
+#include <limits.h>
 #include "visit_il.h"
 #include "expressions.h"
 


### PR DESCRIPTION
Fixes:

```
visit_il.c: In function ‘struct_entry_list_push_back’:
visit_il.c:90:20: error: ‘INT_MAX’ undeclared (first use in this function)
   90 |     if (p->size == INT_MAX)
      |                    ^~~~~~~
visit_il.c:29:1: note: ‘INT_MAX’ is defined in header ‘<limits.h>’; this is probably fixable by adding ‘#include <limits.h>’

```