### PR TITLE
Fix statics in literal functions

### DIFF
--- a/src/visit_il.c
+++ b/src/visit_il.c
@@ -850,51 +850,54 @@ static void d_visit_expression(struct d_visit_ctx* ctx, struct osstream* oss, st
         print_identation_core(&ctx->add_this_before, ctx->indentation);
 
         struct osstream lambda_nameless = { 0 };
-        ss_fprintf(&lambda_nameless, "static ");
         d_print_type(ctx, &lambda_nameless, &p_expression->type, NULL);
         
-        int current_indentation = ctx->indentation;
+        const int current_indentation = ctx->indentation;
         ctx->indentation = 0;
         assert(p_expression->compound_statement != NULL);
 
         const struct declarator* _Opt p_current_function_opt = ctx->p_current_function_opt;
         ctx->p_current_function_opt = p_expression->type_name->abstract_declarator;
     
-        
         const unsigned int current_cake_declarator_number = ctx->cake_declarator_number;
-        ctx->cake_declarator_number = 0; // this makes statics inside of the function literals actually work
-        bool checking_lambda = ctx->checking_lambda;
-        ctx->checking_lambda = true;
-        d_visit_compound_statement(ctx, &lambda_nameless, p_expression->compound_statement);        
-        ctx->checking_lambda = checking_lambda;
+        const bool previous_check_lambda = ctx->checking_lambda;
         
+        ctx->cake_declarator_number = 0; // this makes statics inside of the function literals actually work
+        ctx->checking_lambda = true;
+        
+        d_visit_compound_statement(ctx, &lambda_nameless, p_expression->compound_statement);
+        
+        ctx->checking_lambda = previous_check_lambda;
+        ctx->cake_declarator_number = current_cake_declarator_number;
         
         assert(lambda_nameless.c_str);
         
         struct map_entry* _Opt l = hashmap_find(&ctx->instantiated_lambdas, lambda_nameless.c_str);
-        if (l)
+        if (l != NULL && !ctx->checking_lambda)
         {
             snprintf(name, sizeof(name), CAKE_PREFIX_FOR_CODE_GENERATION "%d_flit", l->data.number);
-            ctx->cake_declarator_number = current_cake_declarator_number;
         }
         else
         {
-            struct osstream lambda_inner = { 0 };
-            struct osstream lambda_sig = { 0 };
-            
-            d_visit_compound_statement(ctx, &lambda_inner, p_expression->compound_statement);
-            ctx->cake_declarator_number += current_cake_declarator_number;
             snprintf(name, sizeof(name), CAKE_PREFIX_FOR_CODE_GENERATION "%d_flit", ctx->cake_declarator_number++);
-            d_print_type(ctx, &lambda_sig, &p_expression->type, name);
             
-            struct hash_item_set i = { 0 };
-            i.number = ctx->cake_declarator_number-1;
-            hashmap_set(&ctx->instantiated_lambdas, lambda_nameless.c_str, &i);
-            hash_item_set_destroy(&i);
-            
-            ss_fprintf(&ctx->add_this_before_external_decl, "static %s\n%s", lambda_sig.c_str, lambda_inner.c_str);
-            ss_close(&lambda_sig);
-            ss_close(&lambda_inner);
+            if(!ctx->checking_lambda)
+            {
+                struct osstream lambda_inner = { 0 };
+                struct osstream lambda_sig = { 0 };
+                d_print_type(ctx, &lambda_sig, &p_expression->type, name);
+                
+                d_visit_compound_statement(ctx, &lambda_inner, p_expression->compound_statement);
+                
+                struct hash_item_set i = { 0 };
+                i.number = current_cake_declarator_number;
+                hashmap_set(&ctx->instantiated_lambdas, lambda_nameless.c_str, &i);
+                hash_item_set_destroy(&i);
+                
+                ss_fprintf(&ctx->add_this_before_external_decl, "static %s\n%s", lambda_sig.c_str, lambda_inner.c_str);
+                ss_close(&lambda_sig);
+                ss_close(&lambda_inner);
+            }
         }
         ctx->p_current_function_opt = p_current_function_opt;
         ctx->indentation = current_indentation;


### PR DESCRIPTION
Fixes
```c
extern int printf(char * format, ...);
#def Funny(V)
    (void (typeof(V) val))
    {
        static typeof(V) lastval;
        printf("%x\n",lastval);
        lastval = val;
    }
    (V)
#enddef

#def Funny2(V)
    (void (typeof(V) val))
    {
        static typeof(V) lastval;
        printf("two : %x\n",lastval);
        lastval = val;
    }
    (V)
#enddef

int main()
{
    Funny(1);
    Funny2(1);
    return 0;
}
```

To be

```c
// Cake 0.12.00 target=x86_x64_gcc

extern int printf(char * format, ...);
static int __Ck1___Ck0_lastval;
static void __Ck0_flit(int val)
{
    printf("%x\n", __Ck1___Ck0_lastval);
    __Ck1___Ck0_lastval = val;
}
static int __Ck3___Ck0_lastval;
static void __Ck2_flit(int val)
{
    printf("two : %x\n", __Ck3___Ck0_lastval);
    __Ck3___Ck0_lastval = val;
}

int main()
{
    __Ck0_flit(1);
    __Ck2_flit(1);
    return 0;
}
```