### PR TITLE
fixing macos builds

### DIFF
--- a/src/build.h
+++ b/src/build.h
@@ -108,6 +108,8 @@ https://github.com/PascalBeyer/Headerless-C-Compiler
 #  define LIBC_MINGW 1
 #elif defined(__dietlibc__)
 #  define LIBC_DIET 1
+#elif defined(__APPLE__) && defined(__MACH__)
+#  define LIBC_DARWIN 1
 #else
 #error LIBC_UNKNOWN
 #endif

--- a/src/lib.c
+++ b/src/lib.c
@@ -754,7 +754,9 @@ static_assert(NUMBER_OF_TARGETS == 5, "add new target here");
 #define CAKE_COMPILE_TIME_SELECTED_TARGET TARGET_X86_X64_GCC
 #endif
 
-
+#if defined(__APPLE__) && defined(__MACH__)
+#define CAKE_COMPILE_TIME_SELECTED_TARGET TARGET_X86_X64_GCC
+#endif
 
 
 const char* target_intN_suffix(enum target target, int size);

--- a/src/target.h
+++ b/src/target.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <assert.h>
 
 /*
 * Compiler options shared with compiler and preprocessor
@@ -49,7 +50,9 @@ static_assert(NUMBER_OF_TARGETS == 5, "add new target here");
 #define CAKE_COMPILE_TIME_SELECTED_TARGET TARGET_X86_X64_GCC
 #endif
 
-
+#if defined(__APPLE__) && defined(__MACH__)
+#define CAKE_COMPILE_TIME_SELECTED_TARGET TARGET_X86_X64_GCC
+#endif
 
 
 const char* target_intN_suffix(enum target target, int size);


### PR DESCRIPTION
When compiling cake on macos arm I would get the following build error. Confirmed that this PR builds on macos.

(base) rileymccarthyrileymccarthy@Rileys-MacBook-Air-3 src % clang build.c -o build && ./build
In file included from build.c:15:
./build.h:112:2: error: LIBC_UNKNOWN
  112 | #error LIBC_UNKNOWN
      |  ^
1 error generated.
(base) rileymccarthyrileymccarthy@Rileys-MacBook-Air-3 src % gcc build.c -o build && ./build
In file included from build.c:15:
./build.h:112:2: error: LIBC_UNKNOWN
#error LIBC_UNKNOWN
 ^
1 error generated.
(base) rileymccarthyrileymccarthy@Rileys-MacBook-Air-3 src % clang build.c -o build && ./build
chdir: ./tools
 clang  -D_CRT_SECURE_NO_WARNINGS maketest.c  -o ../maketest.exe 
 clang  -D_CRT_SECURE_NO_WARNINGS amalgamator.c  -o ../amalgamator.exe 
 clang  -D_CRT_SECURE_NO_WARNINGS -I.. embed.c  ../fs.c ../error.c  -o ../embed.exe 
chdir: ./hoedown
 clang  autolink.c  buffer.c  document.c  escape.c  hoedown.c  html.c  html_blocks.c  html_smartypants.c  stack.c  version.c -o ../../hoedown.exe 
chdir: ..
chdir: ..
 ./hoedown.exe --html-toc --toc-level 3 --autolink --fenced-code ../manual.md >> ./web/manual.html
 ./hoedown.exe  --toc-level 3 --autolink --fenced-code ../manual.md >> ./web/manual.html
 ./hoedown.exe --html-toc --toc-level 3 --autolink --fenced-code ../README.md >> ./web/index.html
 ./hoedown.exe  --toc-level 3 --autolink --fenced-code ../README.md >> ./web/index.html
 ./hoedown.exe --html-toc --toc-level 3 --autolink --fenced-code ../warnings.md >> ./web/warnings.html
 ./hoedown.exe  --toc-level 3 --autolink --fenced-code ../warnings.md >> ./web/warnings.html
 ./hoedown.exe --html-toc --toc-level 3 --autolink --fenced-code ../ownership.md >> ./web/ownership.html
 ./hoedown.exe  --toc-level 3 --autolink --fenced-code ../ownership.md >> ./web/ownership.html
 ./hoedown.exe --html-toc --toc-level 3 --autolink --fenced-code ../code.md >> ./web/code.html
 ./hoedown.exe  --toc-level 3 --autolink --fenced-code ../code.md >> ./web/code.html
 ./maketest.exe unit_test.c  token.c  hashmap.c  console.c  tokenizer.c  osstream.c  fs.c  options.c  object.c  expressions.c  pre_expressions.c  parser.c  visit_defer.c  visit_il.c  flow.c  error.c  target.c  type.c 
Maketest
61 test functions generated at unit_test.c
 ./embed.exe "./include" 
embed generated './include/time.h'
embed generated './include/stdalign.h'
embed generated './include/inttypes.h'
embed generated './include/stdlib.h'
embed generated './include/stdnoreturn.h'
embed generated './include/float.h'
embed generated './include/locale.h'
embed generated './include/limits.h'
embed generated './include/stddef.h'
embed generated './include/wctype.h'
embed generated './include/signal.h'
embed generated './include/threads.h'
embed generated './include/setjmp.h'
embed generated './include/tgmath.h'
embed generated './include/stdckdint.h'
embed generated './include/fenv.h'
embed generated './include/ctype.h'
embed generated './include/wchar.h'
embed generated './include/stdbool.h'
embed generated './include/uchar.h'
embed generated './include/iso646.h'
embed generated './include/math.h'
embed generated './include/errno.h'
embed generated './include/stdbit.h'
embed generated './include/stdio.h'
embed generated './include/stdarg.h'
embed generated './include/stdatomic.h'
embed generated './include/assert.h'
embed generated './include/stdint.h'
embed generated './include/complex.h'
embed generated './include/string.h'
 ./amalgamator.exe -olib.c token.c  hashmap.c  console.c  tokenizer.c  osstream.c  fs.c  options.c  object.c  expressions.c  pre_expressions.c  parser.c  visit_defer.c  visit_il.c  flow.c  error.c  target.c  type.c 
Amalgamated file lib.c generated.
clang  -Wall  -D_DEFAULT_SOURCE  -Wno-unknown-pragmas  -Wno-multichar  -std=c17  -o cake  token.c  hashmap.c  console.c  tokenizer.c  osstream.c  fs.c  options.c  object.c  expressions.c  pre_expressions.c  parser.c  visit_defer.c  visit_il.c  flow.c  error.c  target.c  type.c  main.c 
options.c:337:23: error: use of undeclared identifier 'CAKE_COMPILE_TIME_SELECTED_TARGET'
  337 |     options->target = CAKE_COMPILE_TIME_SELECTED_TARGET;
      |                       ^
1 error generated.
object.c:291:37: warning: format specifies type 'long double' but the argument has type 'double' [-Wformat]
  291 |         snprintf(buffer, sz, "%Lf", a->value.float64);
      |                               ~~~   ^~~~~~~~~~~~~~~~
      |                               %f
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/secure/_stdio.h:57:62: note: expanded from macro 'snprintf'
   57 |   __builtin___snprintf_chk (str, len, 0, __darwin_obsz(str), __VA_ARGS__)
      |                                                              ^~~~~~~~~~~
object.c:251:13: warning: enumeration value 'TYPE_SIGNED_INT64' not handled in switch [-Wswitch]
  251 |     switch (a->value_type)
      |             ^~~~~~~~~~~~~
object.c:1861:26: warning: passing 'const char *' to parameter of type 'void *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
 1861 |                     free(p_member_obj->debug_name);
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/malloc/_malloc.h:56:37: note: passing argument to parameter here
   56 | void  free(void * __unsafe_indexable);
      |                                     ^
object.c:1942:30: warning: passing 'const char *' to parameter of type 'void *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
 1942 |                         free(p_member_obj->debug_name);
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/malloc/_malloc.h:56:37: note: passing argument to parameter here
   56 | void  free(void * __unsafe_indexable);
      |                                     ^
object.c:1976:26: warning: passing 'const char *' to parameter of type 'void *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
 1976 |                     free(p_member_obj->debug_name);
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/malloc/_malloc.h:56:37: note: passing argument to parameter here
   56 | void  free(void * __unsafe_indexable);
      |                                     ^
object.c:2245:17: warning: enumeration value 'CONSTANT_VALUE_NOT_EQUAL' not handled in switch [-Wswitch]
 2245 |         switch (object->state)
      |                 ^~~~~~~~~~~~~
object.c:2603:13: warning: 4 enumeration values not handled in switch: 'TYPE_SIGNED_INT8', 'TYPE_UNSIGNED_INT8', 'TYPE_SIGNED_INT16'... [-Wswitch]
 2603 |     switch (common_type)
      |             ^~~~~~~~~~~
object.c:2658:13: warning: 4 enumeration values not handled in switch: 'TYPE_SIGNED_INT8', 'TYPE_UNSIGNED_INT8', 'TYPE_SIGNED_INT16'... [-Wswitch]
 2658 |     switch (common_type)
      |             ^~~~~~~~~~~
8 warnings generated.
expressions.c:1178:38: warning: initializing 'const unsigned char *' with an expression of type 'char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Wpointer-sign]
 1178 |                 const unsigned char* it = ctx->current->lexeme + 1;
      |                                      ^    ~~~~~~~~~~~~~~~~~~~~~~~~
expressions.c:6381:68: warning: passing 'const struct object *' to parameter of type 'struct object *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
 6381 |                 variables[count] = object_get_non_const_referenced(&expr->object);
      |                                                                    ^~~~~~~~~~~~~
./object.h:202:63: note: passing argument to parameter 'p_object' here
  202 | struct object* object_get_non_const_referenced(struct object* p_object);
      |                                                               ^
2 warnings generated.
parser.c:8773:34: warning: passing 'const struct case_label_list *' to parameter of type 'struct case_label_list *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
 8773 |             case_label_list_push(&ctx->p_current_selection_statement->label_list, p_label);
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./parser.h:1206:51: note: passing argument to parameter 'list' here
 1206 | void case_label_list_push(struct case_label_list* list, struct label* pnew);
      |                                                   ^
parser.c:8858:34: warning: passing 'const struct case_label_list *' to parameter of type 'struct case_label_list *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
 8858 |             case_label_list_push(&ctx->p_current_selection_statement->label_list, p_label);
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./parser.h:1206:51: note: passing argument to parameter 'list' here
 1206 | void case_label_list_push(struct case_label_list* list, struct label* pnew);
      |                                                   ^
parser.c:11347:27: error: use of undeclared identifier 'CAKE_COMPILE_TIME_SELECTED_TARGET'
 11347 |     if (options.target != CAKE_COMPILE_TIME_SELECTED_TARGET)
       |                           ^
2 warnings and 1 error generated.
visit_defer.c:701:5: warning: unused label 'catch_label' [-Wunused-label]
  701 |     catch
      |     ^~~~~
./error.h:23:22: note: expanded from macro 'catch'
   23 | #define catch if (0) catch_label:
      |                      ^~~~~~~~~~~
1 warning generated.
visit_il.c:879:136: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
  879 |             snprintf(generated_function_literal_name, sizeof(generated_function_literal_name), CAKE_PREFIX_FOR_CODE_GENERATION "%d_f", l->data.number);
      |                                                                                                                                 ~~     ^~~~~~~~~~~~~~
      |                                                                                                                                 %zu
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/secure/_stdio.h:57:62: note: expanded from macro 'snprintf'
   57 |   __builtin___snprintf_chk (str, len, 0, __darwin_obsz(str), __VA_ARGS__)
      |                                                              ^~~~~~~~~~~
visit_il.c:2875:21: warning: variable 'declarator_name' set but not used [-Wunused-but-set-variable]
 2875 |         const char* declarator_name = "";
      |                     ^
visit_il.c:3032:5: warning: unused label 'catch_label' [-Wunused-label]
 3032 |     catch
      |     ^~~~~
./error.h:23:22: note: expanded from macro 'catch'
   23 | #define catch if (0) catch_label:
      |                      ^~~~~~~~~~~
3 warnings generated.
flow.c:4721:5: warning: unused label 'catch_label' [-Wunused-label]
 4721 |     catch
      |     ^~~~~
./error.h:23:22: note: expanded from macro 'catch'
   23 | #define catch if (0) catch_label:
      |                      ^~~~~~~~~~~
flow.c:5240:13: warning: 6 enumeration values not handled in switch: 'UNARY_EXPRESSION_GCC__BUILTIN_VA_START', 'UNARY_EXPRESSION_GCC__BUILTIN_VA_END', 'UNARY_EXPRESSION_GCC__BUILTIN_VA_COPY'... [-Wswitch]
 5240 |     switch (p_expression->expression_type)
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
flow.c:6351:5: warning: unused label 'catch_label' [-Wunused-label]
 6351 |     catch
      |     ^~~~~
./error.h:23:22: note: expanded from macro 'catch'
   23 | #define catch if (0) catch_label:
      |                      ^~~~~~~~~~~
flow.c:6510:5: warning: unused label 'catch_label' [-Wunused-label]
 6510 |     catch
      |     ^~~~~
./error.h:23:22: note: expanded from macro 'catch'
   23 | #define catch if (0) catch_label:
      |                      ^~~~~~~~~~~
4 warnings generated.