### PR TITLE
fixed error where amalgamator wouldnt include some system headers, causing building lib.c to fail on linux

### DIFF
--- a/src/tools/amalgamator.c
+++ b/src/tools/amalgamator.c
@@ -65,7 +65,10 @@ void mark_as_included(const char* filename0, struct strlist_node** s_included)
 bool strlist_has(const char* filename0, struct strlist_node** s_included)
 {
     char filename[200];
-    realpath(filename0, filename);
+    if(realpath(filename0, filename) == NULL)
+    {
+        return false;
+    }
 
     bool result = false;
     struct strlist_node* pCurrent = *s_included;


### PR DESCRIPTION
When I tried to build lib.c with
```
gcc lib.c -c -o lib.o
```

it fails on linux because the amalgamator doesn't add all the `sys/` includes to `lib.c`

the fix was just to check the return value of `realpath`.