### PR TITLE
Fixed issue where enum underlying type not being direct (typeof/typedef) causes problems

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -3,6 +3,7 @@
  *  https://github.com/thradams/cake
 */
 
+#include "type.h"
 #pragma safety enable
 
 #include "ownership.h"
@@ -6209,16 +6210,8 @@ struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx* ctx)
                 if (p_enum_specifier->specifier_qualifier_list == NULL)
                     throw;
 
-                struct type enum_underline_type;
-                if (p_enum_specifier->specifier_qualifier_list->typedef_declarator)
-                {
-                    enum_underline_type = p_enum_specifier->specifier_qualifier_list->typedef_declarator->type;
-                    enum_underline_type = type_dup(&enum_underline_type);
-                }
-                else
-                {
-                    enum_underline_type = make_with_type_specifier_flags(p_enum_specifier->specifier_qualifier_list->type_specifier_flags);
-                }
+                struct type enum_underline_type = make_with_specifier_qualifier_list(p_enum_specifier->specifier_qualifier_list);
+                enum_underline_type = type_dup(&enum_underline_type);
 
                 if (!type_is_integer(&enum_underline_type))
                 {

--- a/src/type.c
+++ b/src/type.c
@@ -1701,14 +1701,28 @@ int type_get_integer_rank(const struct type* p_type1)
     return 0;
 }
 
+struct type make_with_specifier_qualifier_list(const struct specifier_qualifier_list *list)
+{
+    if (list->typeof_specifier)
+    {
+        return list->typeof_specifier->type;
+    }
+    else if (list->typedef_declarator)
+    {
+        return list->typedef_declarator->type;
+    }
+    else
+    {
+        return make_with_type_specifier_flags(list->type_specifier_flags);
+    }
+}
+
 struct type type_get_enum_underlying_type(const struct enum_specifier* p)
 {
-    if(!p->specifier_qualifier_list)
+    if (!p->p_complete_enum_specifier->specifier_qualifier_list)
         return type_make_int();
-    if(p->specifier_qualifier_list->typedef_declarator)
-        return p->specifier_qualifier_list->typedef_declarator->type;
     else
-        return make_with_type_specifier_flags(p->specifier_qualifier_list->type_specifier_flags);
+        return make_with_specifier_qualifier_list(p->p_complete_enum_specifier->specifier_qualifier_list);
 }
 
 struct type type_common(const struct type* p_type1, const struct type* p_type2, enum target target)
@@ -2751,12 +2765,8 @@ size_t type_get_alignof(const struct type* p_type, enum target target)
         {
             if (p_type->enum_specifier)
             {
-                enum type_specifier_flags enum_type_specifier_flags =
-                    get_enum_type_specifier_flags(p_type->enum_specifier);
-
-                struct type t = make_with_type_specifier_flags(enum_type_specifier_flags);
+                struct type t = type_get_enum_underlying_type(p_type->enum_specifier);
                 align = type_get_alignof(&t, target);
-                type_destroy(&t);
             }
             else
                 align = get_platform(target)->int_alignment;
@@ -3063,12 +3073,8 @@ enum sizeof_result type_get_sizeof(const struct type* p_type, size_t* size, enum
     {
         if (p_type->enum_specifier)
         {
-            enum type_specifier_flags enum_type_specifier_flags =
-                get_enum_type_specifier_flags(p_type->enum_specifier);
-
-            struct type t = make_with_type_specifier_flags(enum_type_specifier_flags);
+            struct type t = type_get_enum_underlying_type(p_type->enum_specifier);
             enum sizeof_result e = type_get_sizeof(&t, size, target);
-            type_destroy(&t);
             return e;
         }
         else

--- a/src/type.h
+++ b/src/type.h
@@ -420,6 +420,8 @@ struct type make_void_ptr_type();
 struct type make_size_t_type(enum target target);
 struct type make_with_type_specifier_flags(enum type_specifier_flags f);
 
+struct specifier_qualifier_list;
+struct type make_with_specifier_qualifier_list(const struct specifier_qualifier_list *list);
 
 struct type get_function_return_type(const struct type* p_type);
 bool function_returns_void(const struct type* p_type);


### PR DESCRIPTION
for example:
```C
typedef long l;
enum A : typeof(0L) { B };
enum B : l          { C };

_Static_assert(alignof(enum A) == 8, "");
_Static_assert(alignof(enum B) == 8, "");
```