### PR TITLE
Fixing enums

### DIFF
--- a/src/expressions.c
+++ b/src/expressions.c
@@ -1401,7 +1401,7 @@ struct expression* _Owner _Opt primary_expression(struct parser_ctx* ctx, bool i
                 p_expression_node->expression_type = EXPR_PRIMARY_ENUMERATOR;
                 p_expression_node->object = object_dup(&p_enumerator->value);
 
-                p_expression_node->type = type_make_enumerator(p_enumerator->enum_specifier);
+                p_expression_node->type = type_make_enumerator(p_enumerator);
             }
             else if (p_entry &&
                 (p_entry->type == TAG_TYPE_DECLARATOR || p_entry->type == TAG_TYPE_INIT_DECLARATOR))

--- a/src/object.c
+++ b/src/object.c
@@ -127,7 +127,7 @@ static enum object_type to_unsigned(enum object_type t)
     return t;
 }
 
-static bool object_type_is_signed_integer(enum object_type type)
+bool object_type_is_signed_integer(enum object_type type)
 {
     if (object_type_is_signed_bitfield(type))
     return true;
@@ -157,7 +157,7 @@ static bool object_type_is_signed_integer(enum object_type type)
     return false;
 }
 
-static bool object_type_is_unsigned_integer(enum object_type type)
+bool object_type_is_unsigned_integer(enum object_type type)
 {
     if (object_type_is_unsigned_bitfield(type))
     return true;
@@ -638,19 +638,21 @@ struct object object_make_signed_char(signed char value)
     return r;
 }
 
-void object_increment_value(enum target target, struct object* a)
+bool object_increment_value(enum target target, struct object* a)
 {
     if (object_type_is_signed_bitfield(a->value_type))
     {
         int w = object_type_bitfield_width(a->value_type);
+        long long prev = a->value.host_long_long;
         a->value.host_long_long = wrap_signed_integer(a->value.host_long_long + 1, w);
-        return;
+        return prev > a->value.host_long_long;
     }
     if (object_type_is_unsigned_bitfield(a->value_type))
     {
         int w = object_type_bitfield_width(a->value_type);
+        unsigned long long prev = a->value.host_u_long_long;
         a->value.host_u_long_long = wrap_unsigned_integer(a->value.host_u_long_long + 1, w);
-        return;
+        return prev > a->value.host_u_long_long;
     }
 
     switch (a->value_type)
@@ -661,24 +663,27 @@ void object_increment_value(enum target target, struct object* a)
     case TYPE_SIGNED_INT:
     case TYPE_SIGNED_LONG:
     case TYPE_SIGNED_LONG_LONG:
-
+        ;
+        long long llprev = a->value.host_long_long;
         a->value.host_long_long = wrap_signed_integer(a->value.host_long_long + 1, target_get_num_of_bits(target, a->value_type));
-        break;
+        return llprev > a->value.host_long_long;
 
     case TYPE_UNSIGNED_CHAR:
     case TYPE_UNSIGNED_SHORT:
     case TYPE_UNSIGNED_INT:
     case TYPE_UNSIGNED_LONG:
     case TYPE_UNSIGNED_LONG_LONG:
+        ;
+        unsigned long long ullprev = a->value.host_u_long_long;
         a->value.host_u_long_long = wrap_unsigned_integer(a->value.host_u_long_long + 1, target_get_num_of_bits(target, a->value_type));
-        break;
+        return ullprev > a->value.host_u_long_long;
 
     case TYPE_FLOAT:
     case TYPE_DOUBLE:
     case TYPE_LONG_DOUBLE:
         a->value.host_long_double++;
         a->value.host_long_double = resize_floating_point(a->value.host_long_double, target_get_num_of_bits(target, a->value_type));
-        break;
+        return false;
 
     default:
         break;

--- a/src/object.h
+++ b/src/object.h
@@ -110,6 +110,9 @@ struct object        object_make_reference(struct object* object);
 struct object   object_make_signed_bitfield(int width, long long value);
 struct object object_make_unsigned_bitfield(int width, unsigned long long value);
 
+bool object_type_is_signed_integer(enum object_type type);
+bool object_type_is_unsigned_integer(enum object_type type);
+
 /* Bitfield type queries */
 bool object_type_is_bitfield(enum object_type t);
 bool object_type_is_signed_bitfield(enum object_type t);
@@ -128,7 +131,7 @@ enum object_type  type_specifier_to_object_type(const enum type_specifier_flags 
 enum type_specifier_flags object_type_to_type_specifier(enum object_type type);
 
 
-void object_increment_value(enum target target, struct object* a);
+bool object_increment_value(enum target target, struct object* a);
 
 
 signed long long object_to_signed_long_long(const struct object* a);

--- a/src/parser.c
+++ b/src/parser.c
@@ -6007,8 +6007,6 @@ void enum_specifier_delete(struct enum_specifier* _Owner _Opt p)
             return; //lint 29
         }
 
-        // TODO delete this comment:
-        // specifier_qualifier_list_delete(p->specifier_qualifier_list);
         attribute_specifier_sequence_delete(p->attribute_specifier_sequence_opt);
         enumerator_list_destroy(&p->enumerator_list);
         free(p);
@@ -6032,7 +6030,6 @@ struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx* ctx)
         { enumerator-list , }
         enum identifier enum-type-specifier _Opt
     */
-
 
     struct enum_specifier* _Owner _Opt p_enum_specifier = NULL;
     try

--- a/src/parser.c
+++ b/src/parser.c
@@ -6348,13 +6348,13 @@ struct enumerator_list enumerator_list(struct parser_ctx* ctx, struct enum_speci
 
             enum object_type final_type;
 
-            if (max_value <= int_max && min_value >= int_min)
-            {
-                final_type = TYPE_SIGNED_INT;
-            }
-            else if(max_value <= uint_max && min_value >= 0)
+            if(max_value <= uint_max && min_value >= 0)
             {
                 final_type = TYPE_UNSIGNED_INT;
+            }
+            else if (max_value <= int_max && min_value >= int_min)
+            {
+                final_type = TYPE_SIGNED_INT;
             }
             else if(max_value <= ulong_max && min_value >= 0)
             {

--- a/src/parser.c
+++ b/src/parser.c
@@ -6015,11 +6015,6 @@ void enum_specifier_delete(struct enum_specifier* _Owner _Opt p)
     }
 }
 
-bool enum_specifier_has_fixed_underlying_type(const struct enum_specifier* p_enum_specifier)
-{
-    return p_enum_specifier->has_underlying;
-}
-
 struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx* ctx)
 {
     /*
@@ -6055,6 +6050,8 @@ struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx* ctx)
         p_enum_specifier->first_token = ctx->current;
         if (parser_match_tk(ctx, TK_KEYWORD_ENUM) != 0)
             throw;
+
+        p_enum_specifier->integer_type = type_make_int();
 
         p_enum_specifier->attribute_specifier_sequence_opt = attribute_specifier_sequence_opt(ctx);
 
@@ -6198,6 +6195,8 @@ struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx* ctx)
                 //ja existe
                 /* check for another tag with the same name in this scope */
                 p_enum_specifier->p_complete_enum_specifier = p_existing_enum_specifier;
+                p_enum_specifier->integer_type = p_existing_enum_specifier->integer_type;
+                p_enum_specifier->has_underlying = p_existing_enum_specifier->has_underlying;
             }
             else
             {
@@ -6246,7 +6245,25 @@ void enumerator_list_destroy(_Dtor struct enumerator_list* p)
     }
 }
 
-struct enumerator_list enumerator_list(struct parser_ctx* ctx, const struct enum_specifier* p_enum_specifier)
+static void update_enumerator_list_range(struct enumerator *p_enumerator, int64_t *min_value, uint64_t *max_value)
+{
+    bool is_signed = object_type_is_signed_integer(p_enumerator->value.value_type);
+    bool is_negative = is_signed && p_enumerator->value.value.host_long_long < 0;
+    
+    if (is_signed && p_enumerator->value.value.host_long_long < *min_value)
+    {
+        *min_value = p_enumerator->value.value.host_long_long;
+    }
+    if (
+        (is_signed && !is_negative && p_enumerator->value.value.host_long_long > *max_value) ||
+        (!is_signed && p_enumerator->value.value.host_u_long_long > *max_value)
+    )
+    {
+        *max_value = p_enumerator->value.value.host_u_long_long;
+    }
+}
+
+struct enumerator_list enumerator_list(struct parser_ctx* ctx, struct enum_specifier* p_enum_specifier)
 {
 
     /*
@@ -6262,14 +6279,37 @@ struct enumerator_list enumerator_list(struct parser_ctx* ctx, const struct enum
         next_enumerator_value = object_cast(ctx->options.target, vt, &next_enumerator_value);
     }
 
+    // hard limits, only used when enum has fixed underlying type
+    int64_t lo_limit;
+    uint64_t hi_limit;
+
+    if (p_enum_specifier->has_underlying)
+    {
+        if (type_is_signed_integer(&p_enum_specifier->integer_type))
+        {
+            lo_limit = target_signed_min(ctx->options.target, next_enumerator_value.value_type);
+            hi_limit = target_signed_max(ctx->options.target, next_enumerator_value.value_type);
+        }
+        else
+        {
+            lo_limit = 0;
+            hi_limit = target_unsigned_max(ctx->options.target, next_enumerator_value.value_type);
+        }
+    }
+
+    uint64_t max_value = 0;
+    int64_t min_value = 0;
+
     struct enumerator_list enumeratorlist = { 0 };
     struct enumerator* _Owner _Opt p_enumerator = NULL;
     try
     {
-        p_enumerator = enumerator(ctx, p_enum_specifier, &next_enumerator_value);
+        bool next_ovf = false;
+        p_enumerator = enumerator(ctx, p_enum_specifier, &next_enumerator_value, lo_limit, hi_limit, &next_ovf);
         if (p_enumerator == NULL)
             throw;
 
+        update_enumerator_list_range(p_enumerator, &min_value, &max_value);
         enumerator_list_add(&enumeratorlist, p_enumerator);
 
         while (ctx->current != NULL && ctx->current->type == ',')
@@ -6280,10 +6320,71 @@ struct enumerator_list enumerator_list(struct parser_ctx* ctx, const struct enum
 
             if (ctx->current && ctx->current->type != '}')
             {
-                p_enumerator = enumerator(ctx, p_enum_specifier, &next_enumerator_value);
+                p_enumerator = enumerator(ctx, p_enum_specifier, &next_enumerator_value, lo_limit, hi_limit, &next_ovf);
                 if (p_enumerator == NULL)
                     throw;
+                update_enumerator_list_range(p_enumerator, &min_value, &max_value);
                 enumerator_list_add(&enumeratorlist, p_enumerator);
+            }
+        }
+
+        if (!p_enum_specifier->has_underlying)
+        {
+            long long int_min = target_signed_min(ctx->options.target, TYPE_SIGNED_INT);
+            long long int_max = target_signed_max(ctx->options.target, TYPE_SIGNED_INT);
+            
+            unsigned long long uint_max = target_unsigned_max(ctx->options.target, TYPE_UNSIGNED_INT);
+
+            unsigned long long ulong_max = target_unsigned_max(ctx->options.target, TYPE_UNSIGNED_LONG);
+            
+            long long long_min = target_signed_min(ctx->options.target, TYPE_SIGNED_LONG);
+            long long long_max = target_signed_max(ctx->options.target, TYPE_SIGNED_LONG);
+
+            
+            unsigned long long ullong_max = target_unsigned_max(ctx->options.target, TYPE_UNSIGNED_LONG_LONG);
+
+            long long llong_min = target_signed_min(ctx->options.target, TYPE_SIGNED_LONG_LONG);
+            long long llong_max = target_signed_max(ctx->options.target, TYPE_SIGNED_LONG_LONG);
+
+            enum object_type final_type;
+
+            if (max_value <= int_max && min_value >= int_min)
+            {
+                final_type = TYPE_SIGNED_INT;
+            }
+            else if(max_value <= uint_max && min_value >= 0)
+            {
+                final_type = TYPE_UNSIGNED_INT;
+            }
+            else if(max_value <= ulong_max && min_value >= 0)
+            {
+                final_type = TYPE_UNSIGNED_LONG;
+            }
+            else if(max_value <= long_max && min_value >= long_min)
+            {
+                final_type = TYPE_SIGNED_LONG;
+            }
+            else if(max_value <= ullong_max && min_value >= 0)
+            {
+                final_type = TYPE_UNSIGNED_LONG_LONG;
+            }
+            else if(max_value <= llong_max && min_value >= llong_min)
+            {
+                final_type = TYPE_SIGNED_LONG_LONG;
+            }
+            else
+            {
+                diagnostic(C_ERROR_INVALID_TYPE, ctx, ctx->current, NULL, "enum value range unsupported");
+                throw;
+            }
+
+            p_enum_specifier->integer_type = make_with_type_specifier_flags(object_type_to_type_specifier(final_type));
+
+            struct enumerator *it = enumeratorlist.head;
+            while (it)
+            {
+                it->value = object_cast(ctx->options.target, final_type, &it->value);
+                it = it->next;
             }
         }
     }
@@ -6323,7 +6424,10 @@ void enumerator_delete(struct enumerator* _Owner _Opt p)
 
 struct enumerator* _Owner _Opt enumerator(struct parser_ctx* ctx,
     const struct enum_specifier* p_enum_specifier,
-    struct object* p_next_enumerator_value)
+    struct object* p_next_enumerator_value,
+    int64_t lo_limit,
+    uint64_t hi_limit,
+    bool* next_ovf)
 {
     /* TODO: value */
     struct enumerator* _Owner _Opt p_enumerator = NULL;
@@ -6368,27 +6472,42 @@ struct enumerator* _Owner _Opt enumerator(struct parser_ctx* ctx,
             runtime_assert(p_enumerator->constant_expression_opt == NULL);
             p_enumerator->constant_expression_opt = constant_expression(ctx, true, false);
             if (p_enumerator->constant_expression_opt == NULL) throw;
-
-            if (enum_specifier_has_fixed_underlying_type(p_enum_specifier))
+            if (!type_is_integer(&p_enumerator->constant_expression_opt->type))
             {
+                diagnostic(C_ERROR_INVALID_TYPE, ctx, p_enumerator->constant_expression_opt->first_token, NULL, "enumerator initializer must be integer");
+                throw;
+            }
 
-            }
-            else
-            {
-                //if the value is bigger than int the enum whould type must be fixed
-            }
             p_enumerator->value = p_enumerator->constant_expression_opt->object;
+            bool is_signed = object_type_is_signed_integer(p_enumerator->value.value_type);
+            bool is_negative = is_signed && (p_enumerator->value.value.host_long_long < 0);
+
+            if (p_enum_specifier->has_underlying)
+            {
+                if(
+                    (is_signed && ((!is_negative && (uint64_t)p_enumerator->value.value.host_long_long > hi_limit) || p_enumerator->value.value.host_long_long < lo_limit)) ||
+                    (!is_signed && (p_enumerator->value.value.host_u_long_long > hi_limit))
+                )
+                {
+                    diagnostic(C_ERROR_INVALID_TYPE, ctx, p_enumerator->token, NULL, "enumerator value outside of underlying type range");
+                    throw;
+                }
+            }
 
             //fixes #257
             *p_next_enumerator_value = *object_get_referenced(&p_enumerator->value);
 
-            object_increment_value(ctx->options.target, p_next_enumerator_value);
-            //overflow?
+            *next_ovf = object_increment_value(ctx->options.target, p_next_enumerator_value);
         }
         else
         {
+            if (*next_ovf)
+            {
+                diagnostic(C_ERROR_INVALID_TYPE, ctx, p_enumerator->token, NULL, "enumerator overflow");
+                throw;
+            }
             p_enumerator->value = *p_next_enumerator_value;
-            object_increment_value(ctx->options.target, p_next_enumerator_value);
+            *next_ovf = object_increment_value(ctx->options.target, p_next_enumerator_value);
         }
     }
     catch

--- a/src/parser.c
+++ b/src/parser.c
@@ -1158,7 +1158,7 @@ bool first_of_type_qualifier(const struct parser_ctx* ctx)
     return first_of_type_qualifier_token(ctx->current);
 }
 
-struct map_entry* _Opt find_tag(struct parser_ctx* ctx, const char* lexeme)
+struct map_entry* _Opt find_tag(struct parser_ctx* ctx, const char* lexeme, struct scope* _Opt* _Opt ppscope_opt)
 {
     struct scope* _Opt scope = ctx->scopes.tail;
     while (scope)
@@ -1166,6 +1166,8 @@ struct map_entry* _Opt find_tag(struct parser_ctx* ctx, const char* lexeme)
         struct map_entry* _Opt p_entry = hashmap_find(&scope->tags, lexeme);
         if (p_entry)
         {
+            if (ppscope_opt)
+                *ppscope_opt = scope;
             return p_entry;
         }
         scope = scope->previous;
@@ -4792,24 +4794,7 @@ struct type_specifier* _Owner _Opt type_specifier(struct parser_ctx* ctx)
 
 enum type_specifier_flags get_enum_type_specifier_flags(const struct enum_specifier* p_enum_specifier)
 {
-    if (p_enum_specifier->specifier_qualifier_list)
-    {
-        return p_enum_specifier->specifier_qualifier_list->type_specifier_flags;
-    }
-
-    if (p_enum_specifier->p_complete_enum_specifier &&
-        p_enum_specifier->p_complete_enum_specifier->specifier_qualifier_list)
-    {
-        return p_enum_specifier->p_complete_enum_specifier->specifier_qualifier_list->type_specifier_flags;
-    }
-    else if (p_enum_specifier->p_complete_enum_specifier &&
-        p_enum_specifier->p_complete_enum_specifier->p_complete_enum_specifier &&
-        p_enum_specifier->p_complete_enum_specifier->p_complete_enum_specifier->specifier_qualifier_list)
-    {
-        return p_enum_specifier->p_complete_enum_specifier->p_complete_enum_specifier->specifier_qualifier_list->type_specifier_flags;
-    }
-
-    return TYPE_SPECIFIER_INT;
+    return p_enum_specifier->integer_type.type_specifier_flags;
 }
 
 const struct enum_specifier* _Opt get_complete_enum_specifier(const struct enum_specifier* p_enum_specifier)
@@ -6022,7 +6007,8 @@ void enum_specifier_delete(struct enum_specifier* _Owner _Opt p)
             return; //lint 29
         }
 
-        specifier_qualifier_list_delete(p->specifier_qualifier_list);
+        // TODO delete this comment:
+        // specifier_qualifier_list_delete(p->specifier_qualifier_list);
         attribute_specifier_sequence_delete(p->attribute_specifier_sequence_opt);
         enumerator_list_destroy(&p->enumerator_list);
         free(p);
@@ -6031,7 +6017,7 @@ void enum_specifier_delete(struct enum_specifier* _Owner _Opt p)
 
 bool enum_specifier_has_fixed_underlying_type(const struct enum_specifier* p_enum_specifier)
 {
-    return p_enum_specifier->specifier_qualifier_list != NULL;
+    return p_enum_specifier->has_underlying;
 }
 
 struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx* ctx)
@@ -6051,6 +6037,7 @@ struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx* ctx)
         { enumerator-list , }
         enum identifier enum-type-specifier _Opt
     */
+
 
     struct enum_specifier* _Owner _Opt p_enum_specifier = NULL;
     try
@@ -6077,12 +6064,23 @@ struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx* ctx)
             throw;
         }
 
+        struct enum_specifier *prev_decl = NULL; // previous enum definition in the same scope. must be identical
         if (ctx->current->type == TK_IDENTIFIER)
         {
             snprintf(p_enum_specifier->tag_name, sizeof p_enum_specifier->tag_name, "%s", ctx->current->lexeme);
 
             p_enum_specifier->tag_token = ctx->current;
             parser_match(ctx);
+
+            struct scope *sc;
+            struct map_entry *found_tag = find_tag(ctx, p_enum_specifier->tag_token->lexeme, &sc);
+            if (found_tag && sc == ctx->scopes.tail)
+            {
+                if (found_tag->type == TAG_TYPE_ENUM_SPECIFIER)
+                {
+                    prev_decl = found_tag->data.p_enum_specifier;
+                }
+            }
         }
         else
         {
@@ -6102,26 +6100,37 @@ struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx* ctx)
             if (!ctx->inside_generic_association || first_of_type_specifier_token(ctx, p_token_ahead))
             {
                 /* C23 */
+
+                if (prev_decl && !prev_decl->has_underlying)
+                {
+                    diagnostic(C_ERROR_INCOMPATIBLE_TYPES, ctx, ctx->current, NULL, "enum redeclared with underlying type");
+                    throw;
+                }
+
+                p_enum_specifier->has_underlying = true;
+
                 parser_match(ctx);
-                p_enum_specifier->specifier_qualifier_list = specifier_qualifier_list(ctx);
-                if (p_enum_specifier->specifier_qualifier_list == NULL)
+                struct specifier_qualifier_list *list = specifier_qualifier_list(ctx);
+                if (list == NULL)
                     throw;
 
-                struct type enum_underline_type = make_with_specifier_qualifier_list(p_enum_specifier->specifier_qualifier_list);
-                enum_underline_type = type_dup(&enum_underline_type);
+                p_enum_specifier->integer_type = make_with_specifier_qualifier_list(list);
 
-                if (!type_is_integer(&enum_underline_type))
+                if (!type_is_integer(&p_enum_specifier->integer_type))
                 {
-                    type_destroy(&enum_underline_type);
                     diagnostic(C_ERROR_NON_INTEGRAL_ENUM_TYPE,
                         ctx,
-                        p_enum_specifier->specifier_qualifier_list->first_token,
+                        list->first_token,
                         NULL,
                         "expected an integer type");
 
                     throw;
                 }
-                type_destroy(&enum_underline_type);
+                if(prev_decl && !type_is_same(&prev_decl->integer_type, &p_enum_specifier->integer_type, false))
+                {
+                    diagnostic(C_ERROR_INCOMPATIBLE_TYPES, ctx, list->first_token, NULL, "enum redeclared with different underlying type");
+                    throw;
+                }
             }
             else
             {
@@ -6136,6 +6145,12 @@ struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx* ctx)
 
         if (ctx->current->type == '{')
         {
+            if (prev_decl && (p_enum_specifier->has_underlying != prev_decl->has_underlying))
+            {
+                diagnostic(C_ERROR_INCOMPATIBLE_TYPES, ctx, p_enum_specifier->first_token, NULL, "enum redeclared without underlying type");
+                throw;
+            }
+
             if (p_enum_specifier->tag_token)
                 naming_convention_enum_tag(ctx, p_enum_specifier->tag_token);
 
@@ -6241,9 +6256,9 @@ struct enumerator_list enumerator_list(struct parser_ctx* ctx, const struct enum
 
     struct object next_enumerator_value = object_make_signed_int(ctx->options.target, 0);
 
-    if (p_enum_specifier->specifier_qualifier_list)
+    if (p_enum_specifier->has_underlying)
     {
-        enum object_type vt = type_specifier_to_object_type(p_enum_specifier->specifier_qualifier_list->type_specifier_flags, ctx->options.target);
+        enum object_type vt = type_specifier_to_object_type(p_enum_specifier->integer_type.type_specifier_flags, ctx->options.target);
         next_enumerator_value = object_cast(ctx->options.target, vt, &next_enumerator_value);
     }
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -6379,6 +6379,8 @@ struct enumerator_list enumerator_list(struct parser_ctx* ctx, struct enum_speci
             }
 
             p_enum_specifier->integer_type = make_with_type_specifier_flags(object_type_to_type_specifier(final_type));
+            if (final_type == TYPE_UNSIGNED_INT && max_value <= int_max)
+                final_type = TYPE_SIGNED_INT;
 
             struct enumerator *it = enumeratorlist.head;
             while (it)

--- a/src/parser.c
+++ b/src/parser.c
@@ -6107,22 +6107,23 @@ struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx* ctx)
                 struct specifier_qualifier_list *list = specifier_qualifier_list(ctx);
                 if (list == NULL)
                     throw;
-
+                struct token *first_token = list->first_token;
                 p_enum_specifier->integer_type = make_with_specifier_qualifier_list(list);
+
+                specifier_qualifier_list_delete(list);
 
                 if (!type_is_integer(&p_enum_specifier->integer_type))
                 {
                     diagnostic(C_ERROR_NON_INTEGRAL_ENUM_TYPE,
                         ctx,
-                        list->first_token,
+                        first_token,
                         NULL,
                         "expected an integer type");
-
                     throw;
                 }
                 if(prev_decl && !type_is_same(&prev_decl->integer_type, &p_enum_specifier->integer_type, false))
                 {
-                    diagnostic(C_ERROR_INCOMPATIBLE_TYPES, ctx, list->first_token, NULL, "enum redeclared with different underlying type");
+                    diagnostic(C_ERROR_INCOMPATIBLE_TYPES, ctx, first_token, NULL, "enum redeclared with different underlying type");
                     throw;
                 }
             }

--- a/src/parser.h
+++ b/src/parser.h
@@ -662,7 +662,6 @@ struct enum_specifier
     struct type integer_type;
 
     struct attribute_specifier_sequence* _Owner _Opt attribute_specifier_sequence_opt;
-    // struct specifier_qualifier_list* _Owner _Opt specifier_qualifier_list;
 
     char tag_name[200];
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -657,9 +657,12 @@ struct enum_specifier
         - false, only AST OR and some map have the ownership
     */
     bool has_shared_ownership;
+    bool has_underlying;
+
+    struct type integer_type;
 
     struct attribute_specifier_sequence* _Owner _Opt attribute_specifier_sequence_opt;
-    struct specifier_qualifier_list* _Owner _Opt specifier_qualifier_list;
+    // struct specifier_qualifier_list* _Owner _Opt specifier_qualifier_list;
 
     char tag_name[200];
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -633,7 +633,7 @@ struct enumerator_list
 };
 
 struct enumerator_list enumerator_list(struct parser_ctx* ctx,
-    const struct enum_specifier* p_enum_specifier
+    struct enum_specifier* p_enum_specifier
 );
 
 void enumerator_list_destroy(_Dtor struct enumerator_list* p_enum_specifier);
@@ -674,7 +674,6 @@ struct enum_specifier
     struct enum_specifier* _Opt p_complete_enum_specifier;
 };
 
-bool enum_specifier_has_fixed_underlying_type(const struct enum_specifier*);
 struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx*);
 
 struct enum_specifier* _Owner enum_specifier_add_ref(struct enum_specifier* p);
@@ -1717,7 +1716,7 @@ struct enumerator
     struct object value;
 };
 
-struct enumerator* _Owner _Opt enumerator(struct parser_ctx* ctx, const struct enum_specifier* p_enum_specifier, struct object* p_enumerator_value);
+struct enumerator* _Owner _Opt enumerator(struct parser_ctx* ctx, const struct enum_specifier* p_enum_specifier, struct object* p_enumerator_value, int64_t lo_limit, uint64_t hi_limit, bool *next_ovf);
 struct enumerator* _Owner enumerator_add_ref(struct enumerator* p);
 void enumerator_delete(struct enumerator* _Owner _Opt  p);
 

--- a/src/type.c
+++ b/src/type.c
@@ -3059,13 +3059,10 @@ void type_set_int(struct type* p_type)
     p_type->category = TYPE_CATEGORY_ITSELF;
 }
 
-struct type type_make_enumerator(const struct enum_specifier* enum_specifier)
+struct type type_make_enumerator(const struct enumerator* enumerator)
 {
-    struct type t = { 0 };
-    t.type_specifier_flags = TYPE_SPECIFIER_ENUM;
-    t.enum_specifier = enum_specifier;
-    t.category = TYPE_CATEGORY_ITSELF;
-    return t;
+    enum type_specifier_flags flags = object_type_to_type_specifier(enumerator->value.value_type);
+    return make_with_type_specifier_flags(flags);
 }
 
 struct type type_get_enum_type(const struct type* p_type)

--- a/src/type.c
+++ b/src/type.c
@@ -1598,11 +1598,6 @@ struct type make_with_specifier_qualifier_list(const struct specifier_qualifier_
     }
 }
 
-struct type type_get_enum_underlying_type(const struct enum_specifier* p)
-{
-    return p->integer_type;
-}
-
 struct type type_common(const struct type* p_type1, const struct type* p_type2, enum target target)
 {
     //See 6.3.1.8 Usual arithmetic conversions
@@ -1707,7 +1702,7 @@ struct type type_common(const struct type* p_type1, const struct type* p_type2, 
 
     if (type_is_enum(p_type1))
     {
-        promoted_a = type_get_enum_underlying_type(p_type1->enum_specifier);
+        promoted_a = p_type1->enum_specifier->integer_type;
 
     }
     else
@@ -1717,7 +1712,7 @@ struct type type_common(const struct type* p_type1, const struct type* p_type2, 
 
     if (type_is_enum(p_type2))
     {
-        promoted_b = type_get_enum_underlying_type(p_type2->enum_specifier);
+        promoted_b = p_type2->enum_specifier->integer_type;
     }
     else
     {
@@ -2643,7 +2638,7 @@ size_t type_get_alignof(const struct type* p_type, enum target target)
         {
             if (p_type->enum_specifier)
             {
-                struct type t = type_get_enum_underlying_type(p_type->enum_specifier);
+                struct type t = p_type->enum_specifier->integer_type;
                 align = type_get_alignof(&t, target);
             }
             else
@@ -2951,7 +2946,7 @@ enum sizeof_result type_get_sizeof(const struct type* p_type, size_t* size, enum
     {
         if (p_type->enum_specifier)
         {
-            struct type t = type_get_enum_underlying_type(p_type->enum_specifier);
+            struct type t = p_type->enum_specifier->integer_type;
             enum sizeof_result e = type_get_sizeof(&t, size, target);
             return e;
         }
@@ -3285,28 +3280,22 @@ bool type_is_same(const struct type* a, const struct type* b, bool compare_quali
         bool underlying_matched = false;
         if (pa->enum_specifier)
         {
-            if (pa->enum_specifier->p_complete_enum_specifier->has_underlying)
+            struct type a_underlying = pa->enum_specifier->integer_type;
+            if (!type_is_same(&a_underlying, b, compare_qualifiers))
             {
-                struct type a_underlying = type_get_enum_underlying_type(pa->enum_specifier->p_complete_enum_specifier);
-                if (!type_is_same(&a_underlying, b, compare_qualifiers))
-                {
-                    return false;
-                }
-                underlying_matched = true;
+                return false;
             }
+            underlying_matched = true;
         }
 
         if (pb->enum_specifier)
         {
-            if (pb->enum_specifier->p_complete_enum_specifier->has_underlying)
+            struct type b_underlying = pb->enum_specifier->integer_type;
+            if (!type_is_same(a, &b_underlying, compare_qualifiers))
             {
-                struct type b_underlying = type_get_enum_underlying_type(pb->enum_specifier->p_complete_enum_specifier);
-                if (!type_is_same(a, &b_underlying, compare_qualifiers))
-                {
-                    return false;
-                }
-                underlying_matched = true;
+                return false;
             }
+            underlying_matched = true;
         }
 
         if (pa->enum_specifier &&

--- a/src/type.c
+++ b/src/type.c
@@ -3278,7 +3278,7 @@ bool type_is_same(const struct type* a, const struct type* b, bool compare_quali
         if (pa->enum_specifier)
         {
             struct type a_underlying = pa->enum_specifier->integer_type;
-            if (!type_is_same(&a_underlying, b, compare_qualifiers))
+            if (!type_is_same(&a_underlying, pb, compare_qualifiers))
             {
                 return false;
             }
@@ -3288,7 +3288,7 @@ bool type_is_same(const struct type* a, const struct type* b, bool compare_quali
         if (pb->enum_specifier)
         {
             struct type b_underlying = pb->enum_specifier->integer_type;
-            if (!type_is_same(a, &b_underlying, compare_qualifiers))
+            if (!type_is_same(pa, &b_underlying, compare_qualifiers))
             {
                 return false;
             }

--- a/src/type.c
+++ b/src/type.c
@@ -1600,10 +1600,7 @@ struct type make_with_specifier_qualifier_list(const struct specifier_qualifier_
 
 struct type type_get_enum_underlying_type(const struct enum_specifier* p)
 {
-    if (!p->p_complete_enum_specifier->specifier_qualifier_list)
-        return type_make_int();
-    else
-        return make_with_specifier_qualifier_list(p->p_complete_enum_specifier->specifier_qualifier_list);
+    return p->integer_type;
 }
 
 struct type type_common(const struct type* p_type1, const struct type* p_type2, enum target target)
@@ -3083,21 +3080,7 @@ struct type type_get_enum_type(const struct type* p_type)
         if (p_type->enum_specifier == NULL)
             throw;
 
-        const struct enum_specifier* _Opt p_complete_enum_specifier =
-            get_complete_enum_specifier(p_type->enum_specifier);
-
-        if (p_complete_enum_specifier &&
-            p_complete_enum_specifier->specifier_qualifier_list)
-        {
-            struct type t = { 0 };
-            t.type_qualifier_flags = p_complete_enum_specifier->specifier_qualifier_list->type_qualifier_flags;
-            t.type_specifier_flags = p_complete_enum_specifier->specifier_qualifier_list->type_specifier_flags;
-            return t;
-        }
-
-        struct type t = { 0 };
-        t.type_specifier_flags = TYPE_SPECIFIER_INT;
-        return t;
+        return p_type->enum_specifier->integer_type;
     }
     catch
     {
@@ -3302,7 +3285,7 @@ bool type_is_same(const struct type* a, const struct type* b, bool compare_quali
         bool underlying_matched = false;
         if (pa->enum_specifier)
         {
-            if (pa->enum_specifier->p_complete_enum_specifier->specifier_qualifier_list)
+            if (pa->enum_specifier->p_complete_enum_specifier->has_underlying)
             {
                 struct type a_underlying = type_get_enum_underlying_type(pa->enum_specifier->p_complete_enum_specifier);
                 if (!type_is_same(&a_underlying, b, compare_qualifiers))
@@ -3315,7 +3298,7 @@ bool type_is_same(const struct type* a, const struct type* b, bool compare_quali
 
         if (pb->enum_specifier)
         {
-            if (pb->enum_specifier->p_complete_enum_specifier->specifier_qualifier_list)
+            if (pb->enum_specifier->p_complete_enum_specifier->has_underlying)
             {
                 struct type b_underlying = type_get_enum_underlying_type(pb->enum_specifier->p_complete_enum_specifier);
                 if (!type_is_same(a, &b_underlying, compare_qualifiers))

--- a/src/type.c
+++ b/src/type.c
@@ -3061,8 +3061,10 @@ void type_set_int(struct type* p_type)
 
 struct type type_make_enumerator(const struct enumerator* enumerator)
 {
-    enum type_specifier_flags flags = object_type_to_type_specifier(enumerator->value.value_type);
-    return make_with_type_specifier_flags(flags);
+    enum type_specifier_flags flags = object_type_to_type_specifier(enumerator->value.value_type) | TYPE_SPECIFIER_ENUM;
+    struct type type = make_with_type_specifier_flags(flags);
+    type.enum_specifier = enumerator->enum_specifier;
+    return type;
 }
 
 struct type type_get_enum_type(const struct type* p_type)

--- a/src/type.h
+++ b/src/type.h
@@ -415,8 +415,8 @@ struct type type_make_long_double();
 struct type type_make_double();
 struct type type_make_float();
 
-
-struct type type_make_enumerator(const struct enum_specifier* enum_specifier);
+struct enumerator;
+struct type type_make_enumerator(const struct enumerator* enumerator);
 struct type make_void_type();
 struct type make_void_ptr_type();
 struct type make_size_t_type(enum target target);

--- a/tests/unit-tests/parser_enum_flexible.c
+++ b/tests/unit-tests/parser_enum_flexible.c
@@ -1,0 +1,14 @@
+enum A
+{
+    A = 11111111111L
+};
+
+static_assert(_Generic(enum A, unsigned long: 1, default: 0));
+
+enum B
+{
+    B = 11111111111L,
+    C = -1
+};
+
+static_assert(_Generic(enum B, signed long: 1, default: 0));

--- a/tests/unit-tests/parser_enum_indirect_underlying.c
+++ b/tests/unit-tests/parser_enum_indirect_underlying.c
@@ -1,0 +1,6 @@
+typedef long l;
+enum A : typeof(0L) { B };
+enum B : l          { C };
+
+_Static_assert(alignof(enum A) == 8, "");
+_Static_assert(alignof(enum B) == 8, "");


### PR DESCRIPTION
this now works:
```C
enum A
{
    A = 11111111111L
};

static_assert(_Generic(enum A, unsigned long: 1, default: 0));

enum B
{
    B = 11111111111L,
    C = -1
};

static_assert(_Generic(enum B, signed long: 1, default: 0));
```

this is now rejected:
```C
enum A : signed char
{
    A = 500
};
```

this is now rejected:
```C
enum A
{
    A
};

enum A : int
{
    A
};
```
