### PR TITLE
fix forward declared enums

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -1,4 +1,3 @@
-#include "type.h"
 #pragma safety enable
 #include "version.h"
 #include "ownership.h"

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -1,3 +1,4 @@
+#include "type.h"
 #pragma safety enable
 #include "version.h"
 #include "ownership.h"
@@ -3475,7 +3476,7 @@ static void d_print_type_core(struct codegen_ctx* ctx,
                 }
 
             }
-            else if (p_type->enum_specifier)
+            else if (p_type->enum_specifier && !type_is_enumerator(p_type))
             {
                 enum type_specifier_flags enum_type_specifier_flags =
                     get_enum_type_specifier_flags(p_type->enum_specifier);

--- a/src/expressions.c
+++ b/src/expressions.c
@@ -2992,7 +2992,7 @@ static int check_sizeof_argument(struct parser_ctx* ctx,
 
         }
     }
-    else if (category == TYPE_CATEGORY_ITSELF && p_type->enum_specifier && p_type->enum_specifier->integer_type.type_specifier_flags == TYPE_SPECIFIER_NONE)
+    else if (category == TYPE_CATEGORY_ITSELF && p_type->enum_specifier && get_complete_enum_specifier(p_type->enum_specifier) == NULL)
     {
         diagnostic(C_ERROR_STRUCT_IS_INCOMPLETE,
                    ctx,
@@ -3913,7 +3913,7 @@ struct expression* _Owner _Opt unary_expression(struct parser_ctx* ctx, bool is_
                     _Assert(new_expression->type_name->type.enum_specifier);
 
                     const struct enum_specifier* _Opt p_enum_specifier =
-                        get_complete_enum_specifier(new_expression->type_name->type.enum_specifier);
+                        get_enum_specifier_definition(new_expression->type_name->type.enum_specifier);
                     size_t nelements = 0;
                     if (p_enum_specifier)
                     {
@@ -3981,7 +3981,7 @@ struct expression* _Owner _Opt unary_expression(struct parser_ctx* ctx, bool is_
                     _Assert(new_expression->right->type.enum_specifier);
 
                     const struct enum_specifier* _Opt p_enum_specifier =
-                        get_complete_enum_specifier(new_expression->right->type.enum_specifier);
+                        get_enum_specifier_definition(new_expression->right->type.enum_specifier);
                     size_t nelements = 0;
                     if (p_enum_specifier)
                     {

--- a/src/expressions.c
+++ b/src/expressions.c
@@ -2992,7 +2992,7 @@ static int check_sizeof_argument(struct parser_ctx* ctx,
 
         }
     }
-    else if (category == TYPE_CATEGORY_ITSELF && p_type->enum_specifier && get_complete_enum_specifier(p_type->enum_specifier) == NULL)
+    else if (category == TYPE_CATEGORY_ITSELF && p_type->enum_specifier && p_type->enum_specifier->integer_type.type_specifier_flags == TYPE_SPECIFIER_NONE)
     {
         diagnostic(C_ERROR_STRUCT_IS_INCOMPLETE,
                    ctx,

--- a/src/expressions.c
+++ b/src/expressions.c
@@ -2992,6 +2992,15 @@ static int check_sizeof_argument(struct parser_ctx* ctx,
 
         }
     }
+    else if (category == TYPE_CATEGORY_ITSELF && p_type->enum_specifier && p_type->enum_specifier->integer_type.type_specifier_flags == TYPE_SPECIFIER_NONE && p_type->enum_specifier->p_complete_enum_specifier == NULL)
+    {
+        diagnostic(C_ERROR_STRUCT_IS_INCOMPLETE,
+                   ctx,
+                   p_expression->first_token,
+                   NULL,
+                   "enum is incomplete type");
+        return -1;
+    }
 
     return 0; //ok
 }

--- a/src/expressions.c
+++ b/src/expressions.c
@@ -2992,7 +2992,7 @@ static int check_sizeof_argument(struct parser_ctx* ctx,
 
         }
     }
-    else if (category == TYPE_CATEGORY_ITSELF && p_type->enum_specifier && get_complete_enum_specifier(p_type->enum_specifier) == NULL)
+    else if (category == TYPE_CATEGORY_ITSELF && p_type->enum_specifier && get_complete_enum_specifier(p_type->enum_specifier) == NULL && !type_is_enumerator(p_type))
     {
         diagnostic(C_ERROR_STRUCT_IS_INCOMPLETE,
                    ctx,

--- a/src/expressions.c
+++ b/src/expressions.c
@@ -2992,7 +2992,7 @@ static int check_sizeof_argument(struct parser_ctx* ctx,
 
         }
     }
-    else if (category == TYPE_CATEGORY_ITSELF && p_type->enum_specifier && p_type->enum_specifier->integer_type.type_specifier_flags == TYPE_SPECIFIER_NONE && p_type->enum_specifier->p_complete_enum_specifier == NULL)
+    else if (category == TYPE_CATEGORY_ITSELF && p_type->enum_specifier && get_complete_enum_specifier(p_type->enum_specifier) == NULL)
     {
         diagnostic(C_ERROR_STRUCT_IS_INCOMPLETE,
                    ctx,

--- a/src/object.c
+++ b/src/object.c
@@ -1481,6 +1481,15 @@ struct object* _Owner _Opt make_object_ptr_core(const struct type* p_type,
 
         if (p_type->struct_or_union_specifier == NULL)
         {
+            if (p_type->enum_specifier)
+            {
+                const struct enum_specifier* complete_enum_specifier = get_complete_enum_specifier(p_type->enum_specifier);
+                if (complete_enum_specifier == NULL)
+                {
+                    return NULL;
+                }
+            }
+
             p_object = calloc(1, sizeof * p_object);
             if (p_object == NULL)
                 throw;

--- a/src/object.c
+++ b/src/object.c
@@ -1483,8 +1483,7 @@ struct object* _Owner _Opt make_object_ptr_core(const struct type* p_type,
         {
             if (p_type->enum_specifier)
             {
-                const struct enum_specifier* complete_enum_specifier = get_complete_enum_specifier(p_type->enum_specifier);
-                if (complete_enum_specifier == NULL)
+                if (p_type->enum_specifier->integer_type.type_specifier_flags == TYPE_SPECIFIER_NONE)
                 {
                     return NULL;
                 }

--- a/src/object.c
+++ b/src/object.c
@@ -1481,12 +1481,14 @@ struct object* _Owner _Opt make_object_ptr_core(const struct type* p_type,
 
         if (p_type->struct_or_union_specifier == NULL)
         {
-            if (p_type->enum_specifier)
+            if (p_type->enum_specifier && p_type->type_specifier_flags == TYPE_SPECIFIER_NONE)
             {
-                if (p_type->enum_specifier->integer_type.type_specifier_flags == TYPE_SPECIFIER_NONE)
+                const struct enum_specifier* complete = get_complete_enum_specifier(p_type->enum_specifier);
+                if (complete == NULL)
                 {
                     return NULL;
                 }
+                p_type = &complete->integer_type;
             }
 
             p_object = calloc(1, sizeof * p_object);

--- a/src/object.c
+++ b/src/object.c
@@ -1481,13 +1481,12 @@ struct object* _Owner _Opt make_object_ptr_core(const struct type* p_type,
 
         if (p_type->struct_or_union_specifier == NULL)
         {
-            if (p_type->enum_specifier && p_type->type_specifier_flags == TYPE_SPECIFIER_NONE)
+            if (p_type->enum_specifier && p_type->type_specifier_flags == TYPE_SPECIFIER_ENUM)
             {
                 const struct enum_specifier* complete = get_complete_enum_specifier(p_type->enum_specifier);
                 if (complete == NULL)
-                {
-                    return NULL;
-                }
+                    throw;
+
                 p_type = &complete->integer_type;
             }
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -2896,7 +2896,7 @@ static void check_unused_parameters(const struct parser_ctx* ctx, struct paramet
 
 int check_function_types_complete(struct parser_ctx* ctx, struct declarator* funcdecl)
 {
-    runtime_assert(funcdecl->type.category == TYPE_CATEGORY_FUNCTION);
+    _Assert(funcdecl->type.category == TYPE_CATEGORY_FUNCTION);
 
     struct token* diagtok = NULL;
     if (funcdecl->name_opt)
@@ -3688,7 +3688,9 @@ struct init_declarator* _Owner _Opt init_declarator(struct parser_ctx* ctx,
                     {
                         if (p_init_declarator->p_declarator->type.enum_specifier)
                         {
-                            
+                            struct block_item* new_block_item = calloc(1, sizeof * new_block_item);
+                            new_block_item->declarator = p_init_declarator->p_declarator;
+                            block_item_list_add(&ctx->used_incomplete_enums, new_block_item);
                         }
                         else
                         {
@@ -4927,20 +4929,20 @@ const struct enum_specifier* _Opt get_complete_enum_specifier(const struct enum_
       Then the result will be there at end of first pass.
       This crazy code finds the complete definition of the struct if exists.
     */
-    if (p_enum_specifier->enumerator_list.head)
+    if (p_enum_specifier->integer_type.type_specifier_flags != TYPE_SPECIFIER_NONE)
     {
         /*p_struct_or_union_specifier is complete*/
         return p_enum_specifier;
     }
     else if (p_enum_specifier->p_complete_enum_specifier &&
-        p_enum_specifier->p_complete_enum_specifier->enumerator_list.head)
+        p_enum_specifier->p_complete_enum_specifier->integer_type.type_specifier_flags != TYPE_SPECIFIER_NONE)
     {
         /*p_struct_or_union_specifier is the first seem tag tag points directly to complete*/
         return p_enum_specifier->p_complete_enum_specifier;
     }
     else if (p_enum_specifier->p_complete_enum_specifier &&
         p_enum_specifier->p_complete_enum_specifier->p_complete_enum_specifier &&
-        p_enum_specifier->p_complete_enum_specifier->p_complete_enum_specifier->enumerator_list.head)
+        p_enum_specifier->p_complete_enum_specifier->p_complete_enum_specifier->integer_type.type_specifier_flags != TYPE_SPECIFIER_NONE)
     {
         /* all others points to the first seem that points to the complete*/
         return p_enum_specifier->p_complete_enum_specifier->p_complete_enum_specifier;
@@ -6195,7 +6197,9 @@ struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx* ctx)
             throw;
         }
 
-        struct enum_specifier* _Opt prev_decl = NULL; // previous enum definition in the same scope. must be identical
+
+        struct enum_specifier* prev_decl_same_scope = NULL; // previous enum definition in the same scope. must be identical
+
         if (ctx->current->type == TK_IDENTIFIER)
         {
             snprintf(p_enum_specifier->tag_name, sizeof p_enum_specifier->tag_name, "%s", ctx->current->lexeme);
@@ -6209,7 +6213,8 @@ struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx* ctx)
             {
                 if (found_tag->type == TAG_TYPE_ENUM_SPECIFIER)
                 {
-                    prev_decl = found_tag->data.p_enum_specifier;
+                    prev_decl_same_scope = found_tag->data.p_enum_specifier;
+                    p_enum_specifier->p_complete_enum_specifier = prev_decl_same_scope;
                 }
             }
         }
@@ -6234,7 +6239,7 @@ struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx* ctx)
             {
                 /* C23 */
 
-                if (prev_decl && !prev_decl->has_underlying)
+                if (prev_decl_same_scope && !prev_decl_same_scope->has_underlying)
                 {
                     diagnostic(C_ERROR_INCOMPATIBLE_TYPES, ctx, ctx->current, NULL, "enum redeclared with underlying type");
                     throw;
@@ -6261,7 +6266,7 @@ struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx* ctx)
                         "expected an integer type");
                     throw;
                 }
-                if (prev_decl && !type_is_same(&prev_decl->integer_type, &p_enum_specifier->integer_type, false))
+                if (prev_decl_same_scope && !type_is_same(&prev_decl_same_scope->integer_type, &p_enum_specifier->integer_type, false))
                 {
                     diagnostic(C_ERROR_INCOMPATIBLE_TYPES, ctx, first_token, NULL, "enum redeclared with different underlying type");
                     throw;
@@ -6280,17 +6285,22 @@ struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx* ctx)
 
         if (ctx->current->type == '{')
         {
-            if (prev_decl && (p_enum_specifier->has_underlying != prev_decl->has_underlying))
+            if (prev_decl_same_scope)
             {
-                diagnostic(C_ERROR_INCOMPATIBLE_TYPES, ctx, p_enum_specifier->first_token, NULL, "enum redeclared without underlying type");
-                throw;
+                if (p_enum_specifier->has_underlying != prev_decl_same_scope->has_underlying)
+                {
+                    diagnostic(C_ERROR_INCOMPATIBLE_TYPES, ctx, p_enum_specifier->first_token, NULL, "enum redeclared without underlying type");
+                    throw;
+                }
+
+                prev_decl_same_scope->p_complete_enum_specifier = p_enum_specifier;
             }
 
             if (p_enum_specifier->tag_token)
                 naming_convention_enum_tag(ctx, p_enum_specifier->tag_token);
 
             /*points to itself*/
-            // p_enum_specifier->p_complete_enum_specifier = p_enum_specifier;
+            p_enum_specifier->p_complete_enum_specifier = p_enum_specifier;
 
             if (parser_match_tk(ctx, '{') != 0)
                 throw;
@@ -6327,7 +6337,7 @@ struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx* ctx)
                 p_existing_enum_specifier = find_enum_specifier(ctx, p_enum_specifier->tag_token->lexeme);
             }
 
-            if (p_existing_enum_specifier && p_existing_enum_specifier->integer_type.type_specifier_flags != TYPE_SPECIFIER_NONE)
+            if (p_existing_enum_specifier)
             {
                 //p_existing_enum_specifier->p_complete_enum_specifier = p_enum_specifier;
                 //ja existe
@@ -6341,11 +6351,11 @@ struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx* ctx)
             else
             {
                 /* tag not found anywhere; add it */
+
+                p_enum_specifier->p_complete_enum_specifier = p_enum_specifier;
                 struct hash_item_set item = { 0 };
                 item.p_enum_specifier = enum_specifier_add_ref(p_enum_specifier);
                 hashmap_set(&ctx->scopes.tail->tags, p_enum_specifier->tag_name, &item);
-                if (p_enum_specifier->integer_type.type_specifier_flags != TYPE_SPECIFIER_NONE)
-                    p_enum_specifier->p_complete_enum_specifier = p_enum_specifier;
                 hash_item_set_destroy(&item);
             }
         }
@@ -12587,12 +12597,25 @@ struct declaration_list translation_unit(struct parser_ctx* ctx, bool* berror)
 
         check_unused_static_declarators(ctx, &declaration_list);
 
+        // check that all enums that have objects are defined
+        struct block_item* decl = ctx->used_incomplete_enums.head;
+        while (decl)
+        {
+            const struct enum_specifier* declared_enum = decl->declarator->type.enum_specifier;
+            assert(declared_enum != NULL);
+            if (get_complete_enum_specifier(declared_enum) == NULL)
+            {
+                diagnostic(C_ERROR_STRUCT_IS_INCOMPLETE, ctx, declared_enum->first_token, NULL, "enum incomplete");
+            }
+            decl = decl->next;
+        }
     }
     catch
     {
         *berror = true;
     }
 
+    block_item_list_destroy(&ctx->used_incomplete_enums);
     diagnostic_queue_flush(&ctx->diagnostic_queue, ctx);
 
     if (ctx->p_report->error_count == 0 && ctx->options.flow_analysis)

--- a/src/parser.c
+++ b/src/parser.c
@@ -4929,20 +4929,20 @@ const struct enum_specifier* _Opt get_complete_enum_specifier(const struct enum_
       Then the result will be there at end of first pass.
       This crazy code finds the complete definition of the struct if exists.
     */
-    if (p_enum_specifier->integer_type.type_specifier_flags != TYPE_SPECIFIER_NONE)
+    if (p_enum_specifier->enumerator_list.head)
     {
         /*p_struct_or_union_specifier is complete*/
         return p_enum_specifier;
     }
     else if (p_enum_specifier->p_complete_enum_specifier &&
-        p_enum_specifier->p_complete_enum_specifier->integer_type.type_specifier_flags != TYPE_SPECIFIER_NONE)
+        p_enum_specifier->p_complete_enum_specifier->enumerator_list.head)
     {
         /*p_struct_or_union_specifier is the first seem tag tag points directly to complete*/
         return p_enum_specifier->p_complete_enum_specifier;
     }
     else if (p_enum_specifier->p_complete_enum_specifier &&
         p_enum_specifier->p_complete_enum_specifier->p_complete_enum_specifier &&
-        p_enum_specifier->p_complete_enum_specifier->p_complete_enum_specifier->integer_type.type_specifier_flags != TYPE_SPECIFIER_NONE)
+        p_enum_specifier->p_complete_enum_specifier->p_complete_enum_specifier->enumerator_list.head)
     {
         /* all others points to the first seem that points to the complete*/
         return p_enum_specifier->p_complete_enum_specifier->p_complete_enum_specifier;

--- a/src/parser.c
+++ b/src/parser.c
@@ -6294,6 +6294,10 @@ struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx* ctx)
 
                 prev_decl_same_scope->p_complete_enum_specifier = p_enum_specifier;
             }
+            if (!p_enum_specifier->has_underlying)
+            {
+                p_enum_specifier->integer_type.type_specifier_flags = TYPE_SPECIFIER_INT;
+            }
 
             if (p_enum_specifier->tag_token)
                 naming_convention_enum_tag(ctx, p_enum_specifier->tag_token);

--- a/src/parser.c
+++ b/src/parser.c
@@ -3645,6 +3645,7 @@ struct init_declarator* _Owner _Opt init_declarator(struct parser_ctx* ctx,
 
                 if (er != 0)
                 {
+                    diagnostic(C_ERROR_STRUCT_IS_INCOMPLETE, ctx, p_init_declarator->p_declarator->first_token_opt, NULL, "type incomplete");
                     throw;
                 }
 
@@ -6321,11 +6322,6 @@ struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx* ctx)
                     throw;
                 }
 
-                prev_decl_same_scope->p_complete_enum_specifier = p_enum_specifier;
-            }
-            if (!p_enum_specifier->has_underlying)
-            {
-                p_enum_specifier->integer_type.type_specifier_flags = TYPE_SPECIFIER_INT;
             }
 
             if (p_enum_specifier->tag_token)
@@ -6360,6 +6356,9 @@ struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx* ctx)
             item.p_enum_specifier = enum_specifier_add_ref(p_enum_specifier);
             hashmap_set(&ctx->scopes.tail->tags, p_enum_specifier->tag_name, &item);
             hash_item_set_destroy(&item);
+
+            if (prev_decl_same_scope)
+                prev_decl_same_scope->p_complete_enum_specifier = p_enum_specifier;
         }
         else
         {
@@ -6376,9 +6375,6 @@ struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx* ctx)
                 /* check for another tag with the same name in this scope */
 
                 p_enum_specifier->p_complete_enum_specifier = p_existing_enum_specifier;
-                // type_destroy(&p_enum_specifier->integer_type);
-                // p_enum_specifier->integer_type = type_dup(&p_existing_enum_specifier->integer_type);
-                // p_enum_specifier->has_underlying = p_existing_enum_specifier->has_underlying;
             }
             else
             {
@@ -6454,7 +6450,7 @@ struct enumerator_list enumerator_list(struct parser_ctx* ctx, struct enum_speci
         enumerator_list ',' enumerator
      */
 
-    struct object next_enumerator_value = object_make_unsigned_long_long(ctx->options.target, 0);
+    struct object next_enumerator_value = object_make_signed_int(ctx->options.target, 0);
 
     if (p_enum_specifier->has_underlying)
     {
@@ -6620,7 +6616,7 @@ struct enumerator* _Owner _Opt enumerator(struct parser_ctx* ctx,
     unsigned long long* max_value,
     bool* next_ovf)
 {
-    *next_ovf = false;
+    // *next_ovf = false;
 
     struct enumerator* _Owner _Opt p_enumerator = NULL;
     try

--- a/src/parser.c
+++ b/src/parser.c
@@ -4918,10 +4918,39 @@ struct type_specifier* _Owner _Opt type_specifier(struct parser_ctx* ctx)
 
 enum type_specifier_flags get_enum_type_specifier_flags(const struct enum_specifier* p_enum_specifier)
 {
-    return p_enum_specifier->integer_type.type_specifier_flags;
+    if (p_enum_specifier->integer_type.type_specifier_flags != TYPE_SPECIFIER_NONE)
+        return p_enum_specifier->integer_type.type_specifier_flags;
+
+    const struct enum_specifier* complete = get_complete_enum_specifier(p_enum_specifier);
+    if (complete)
+    {
+        return complete->integer_type.type_specifier_flags;
+    }
+    return TYPE_SPECIFIER_NONE;
 }
 
 const struct enum_specifier* _Opt get_complete_enum_specifier(const struct enum_specifier* p_enum_specifier)
+{
+    if (p_enum_specifier->integer_type.type_specifier_flags != TYPE_SPECIFIER_NONE)
+    {
+        return p_enum_specifier;
+    }
+    else if (p_enum_specifier->p_complete_enum_specifier &&
+        p_enum_specifier->p_complete_enum_specifier->integer_type.type_specifier_flags != TYPE_SPECIFIER_NONE)
+    {
+        return p_enum_specifier->p_complete_enum_specifier;
+    }
+    else if (p_enum_specifier->p_complete_enum_specifier &&
+        p_enum_specifier->p_complete_enum_specifier->p_complete_enum_specifier &&
+        p_enum_specifier->p_complete_enum_specifier->p_complete_enum_specifier->integer_type.type_specifier_flags != TYPE_SPECIFIER_NONE)
+    {
+        return p_enum_specifier->p_complete_enum_specifier->p_complete_enum_specifier;
+    }
+    
+    return NULL;
+}
+
+const struct enum_specifier* _Opt get_enum_specifier_definition(const struct enum_specifier* p_enum_specifier)
 {
     /*
       The way cake find the complete struct is using one pass.. for this task is uses double indirection.
@@ -6347,9 +6376,9 @@ struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx* ctx)
                 /* check for another tag with the same name in this scope */
 
                 p_enum_specifier->p_complete_enum_specifier = p_existing_enum_specifier;
-                type_destroy(&p_enum_specifier->integer_type);
-                p_enum_specifier->integer_type = type_dup(&p_existing_enum_specifier->integer_type);
-                p_enum_specifier->has_underlying = p_existing_enum_specifier->has_underlying;
+                // type_destroy(&p_enum_specifier->integer_type);
+                // p_enum_specifier->integer_type = type_dup(&p_existing_enum_specifier->integer_type);
+                // p_enum_specifier->has_underlying = p_existing_enum_specifier->has_underlying;
             }
             else
             {
@@ -10434,7 +10463,7 @@ struct label* _Owner _Opt label(struct parser_ctx* ctx, struct attribute_specifi
                     ctx->p_current_switch_statement->condition->expression &&
                     ctx->p_current_switch_statement->condition->expression->type.enum_specifier)
                 {
-                    p_enum_specifier = get_complete_enum_specifier(ctx->p_current_switch_statement->condition->expression->type.enum_specifier);
+                    p_enum_specifier = get_enum_specifier_definition(ctx->p_current_switch_statement->condition->expression->type.enum_specifier);
                 }
 
                 if (p_enum_specifier)
@@ -11648,7 +11677,7 @@ struct selection_statement* _Owner _Opt selection_statement(struct parser_ctx* c
                     p_selection_statement->condition->expression &&
                     p_selection_statement->condition->expression->type.enum_specifier)
                 {
-                    p_enum_specifier = get_complete_enum_specifier(p_selection_statement->condition->expression->type.enum_specifier);
+                    p_enum_specifier = get_enum_specifier_definition(p_selection_statement->condition->expression->type.enum_specifier);
                 }
 
                 if (p_enum_specifier)
@@ -12606,7 +12635,7 @@ struct declaration_list translation_unit(struct parser_ctx* ctx, bool* berror)
         {
             const struct enum_specifier* declared_enum = decl->declarator->type.enum_specifier;
             assert(declared_enum != NULL);
-            if (get_complete_enum_specifier(declared_enum) == NULL)
+            if (get_enum_specifier_definition(declared_enum) == NULL)
             {
                 diagnostic(C_ERROR_STRUCT_IS_INCOMPLETE, ctx, declared_enum->first_token, NULL, "enum incomplete");
             }

--- a/src/parser.c
+++ b/src/parser.c
@@ -3,6 +3,7 @@
  *  https://github.com/thradams/cake
 */
 
+#include "options.h"
 #pragma safety enable
 
 #include "ownership.h"
@@ -2893,6 +2894,38 @@ static void check_unused_parameters(const struct parser_ctx* ctx, struct paramet
     }
 }
 
+int check_function_types_complete(struct parser_ctx* ctx, struct declarator* funcdecl)
+{
+    runtime_assert(funcdecl->type.category == TYPE_CATEGORY_FUNCTION);
+
+    struct token* diagtok = NULL;
+    if (funcdecl->name_opt)
+        diagtok = funcdecl->name_opt;
+    else if (funcdecl->first_token_opt)
+        diagtok = funcdecl->first_token_opt;
+    else
+        diagtok = ctx->current;
+
+    struct type return_type = get_function_return_type(&funcdecl->type);
+    if (type_is_incomplete(&return_type))
+    {
+        diagnostic(C_ERROR_STRUCT_IS_INCOMPLETE, ctx, diagtok, NULL, "function has incomplete return type");
+        return 1;
+    }
+    struct param_list params = funcdecl->type.params;
+    struct param* param = params.head;
+    while (param)
+    {
+        if (type_is_incomplete(&param->type))
+        {
+            diagnostic(C_ERROR_STRUCT_IS_INCOMPLETE, ctx, diagtok, NULL, "function has incomplete parameter type");
+            return 1;
+        }
+        param = param->next;
+    }
+    return 0;
+}
+
 struct secondary_block* _Owner _Opt secondary_block(struct parser_ctx* ctx);
 
 struct declaration* _Owner _Opt declaration(struct parser_ctx* ctx,
@@ -2986,6 +3019,9 @@ struct declaration* _Owner _Opt declaration(struct parser_ctx* ctx,
 
                 throw;
             }
+
+            if (check_function_types_complete(ctx, p_declarator) != 0)
+                throw;
 
             struct function_declarator* _Opt pfuncdecl = declarator_find_function_declarator(p_declarator);
             if (pfuncdecl == NULL) throw;
@@ -3650,8 +3686,15 @@ struct init_declarator* _Owner _Opt init_declarator(struct parser_ctx* ctx,
                     }
                     else
                     {
-                        diagnostic(C_ERROR_STRUCT_IS_INCOMPLETE, ctx, p_init_declarator->p_declarator->first_token_opt, NULL, "incomplete struct/union type");
-                        throw;
+                        if (p_init_declarator->p_declarator->type.enum_specifier)
+                        {
+                            
+                        }
+                        else
+                        {
+                            diagnostic(C_ERROR_STRUCT_IS_INCOMPLETE, ctx, p_init_declarator->p_declarator->first_token_opt, NULL, "incomplete struct/union type");
+                            throw;
+                        }
                     }
                 }
 
@@ -6144,8 +6187,6 @@ struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx* ctx)
         if (parser_match_tk(ctx, TK_KEYWORD_ENUM) != 0)
             throw;
 
-        p_enum_specifier->integer_type = type_make_int();
-
         p_enum_specifier->attribute_specifier_sequence_opt = attribute_specifier_sequence_opt(ctx);
 
         if (ctx->current == NULL)
@@ -6249,7 +6290,7 @@ struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx* ctx)
                 naming_convention_enum_tag(ctx, p_enum_specifier->tag_token);
 
             /*points to itself*/
-            p_enum_specifier->p_complete_enum_specifier = p_enum_specifier;
+            // p_enum_specifier->p_complete_enum_specifier = p_enum_specifier;
 
             if (parser_match_tk(ctx, '{') != 0)
                 throw;
@@ -6276,7 +6317,6 @@ struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx* ctx)
             struct hash_item_set item = { 0 };
             item.p_enum_specifier = enum_specifier_add_ref(p_enum_specifier);
             hashmap_set(&ctx->scopes.tail->tags, p_enum_specifier->tag_name, &item);
-            p_enum_specifier->p_complete_enum_specifier = p_enum_specifier;
             hash_item_set_destroy(&item);
         }
         else
@@ -6286,11 +6326,13 @@ struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx* ctx)
             {
                 p_existing_enum_specifier = find_enum_specifier(ctx, p_enum_specifier->tag_token->lexeme);
             }
-            if (p_existing_enum_specifier)
+
+            if (p_existing_enum_specifier && p_existing_enum_specifier->integer_type.type_specifier_flags != TYPE_SPECIFIER_NONE)
             {
                 //p_existing_enum_specifier->p_complete_enum_specifier = p_enum_specifier;
                 //ja existe
                 /* check for another tag with the same name in this scope */
+
                 p_enum_specifier->p_complete_enum_specifier = p_existing_enum_specifier;
                 type_destroy(&p_enum_specifier->integer_type);
                 p_enum_specifier->integer_type = type_dup(&p_existing_enum_specifier->integer_type);
@@ -6302,7 +6344,8 @@ struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx* ctx)
                 struct hash_item_set item = { 0 };
                 item.p_enum_specifier = enum_specifier_add_ref(p_enum_specifier);
                 hashmap_set(&ctx->scopes.tail->tags, p_enum_specifier->tag_name, &item);
-                p_enum_specifier->p_complete_enum_specifier = p_enum_specifier;
+                if (p_enum_specifier->integer_type.type_specifier_flags != TYPE_SPECIFIER_NONE)
+                    p_enum_specifier->p_complete_enum_specifier = p_enum_specifier;
                 hash_item_set_destroy(&item);
             }
         }
@@ -7890,7 +7933,7 @@ struct parameter_declaration* _Owner _Opt parameter_declaration(struct parser_ct
             if (er != 0)
             {
                 //diagnostic(C_ERROR_STRUCT_IS_INCOMPLETE, ctx, p_init_declarator->p_declarator->first_token_opt, NULL, "incomplete struct/union type");
-                throw;
+                //throw;
             }
         }
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -3,7 +3,6 @@
  *  https://github.com/thradams/cake
 */
 
-#include "options.h"
 #pragma safety enable
 
 #include "ownership.h"

--- a/src/parser.h
+++ b/src/parser.h
@@ -113,6 +113,16 @@ void diagnostic_queue_destroy(_Dtor struct diagnostic_queue* q);
 
 int parse_diagnostic_suppression(const char* p, int ids[], int ids_max);
 
+struct block_item_list
+{
+    /*
+     block-item-list:
+       block-item
+       block-item-list block-item
+    */
+    struct block_item* _Owner _Opt head;
+    struct block_item* _Opt tail;
+};
 
 struct parser_ctx
 {
@@ -122,6 +132,8 @@ struct parser_ctx
       file scope -> function params -> function -> inner scope
     */
     struct scope_list scopes;
+
+    struct block_item_list used_incomplete_enums;
 
     /*
     * Points to the function we're in. Or null in file scope.
@@ -1203,17 +1215,6 @@ struct member_declarator_list* _Owner _Opt member_declarator_list(struct parser_
 void member_declarator_list_delete(_Dtor struct member_declarator_list* _Owner _Opt p);
 void member_declarator_list_add(struct member_declarator_list* list, struct member_declarator* _Owner p_item);
 
-struct block_item_list
-{
-    /*
-     block-item-list:
-       block-item
-       block-item-list block-item
-    */
-    struct block_item* _Owner _Opt head;
-    struct block_item* _Opt tail;
-};
-
 struct block_item_list block_item_list(struct parser_ctx* ctx, bool* error);
 void block_item_list_destroy(_Dtor struct block_item_list* p);
 void block_item_list_add(struct block_item_list* list, struct block_item* _Owner p_item);
@@ -1446,6 +1447,7 @@ struct block_item
     */
     struct token* first_token; //?necessary
     struct declaration* _Owner _Opt declaration;
+    struct declarator* _Owner _Opt declarator;
     struct unlabeled_statement* _Owner _Opt unlabeled_statement;
     struct label* _Owner _Opt label;
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -690,6 +690,7 @@ struct enum_specifier* _Owner _Opt enum_specifier(struct parser_ctx*);
 struct enum_specifier* _Owner enum_specifier_add_ref(struct enum_specifier* p);
 void enum_specifier_delete(_Dtor struct enum_specifier* _Owner _Opt p);
 const struct enum_specifier* _Opt get_complete_enum_specifier(const struct enum_specifier* p_enum_specifier);
+const struct enum_specifier* _Opt get_enum_specifier_definition(const struct enum_specifier* p_enum_specifier);
 enum type_specifier_flags get_enum_type_specifier_flags(const struct enum_specifier* p_enum_specifier);
 
 const struct enumerator* _Opt find_enumerator_by_value(struct parser_ctx* ctx, const struct enum_specifier* p_enum_specifier, const struct object* object);

--- a/src/type.c
+++ b/src/type.c
@@ -1719,7 +1719,7 @@ struct type type_common(const struct type* p_type1, const struct type* p_type2, 
     struct type promoted_b = { 0 };
 
 
-    if (type_is_enum(p_type1))
+    if (type_is_enum(p_type1) && !type_is_enumerator(p_type1))
     {
         _Assert(p_type1->enum_specifier);
         const struct enum_specifier* complete = get_complete_enum_specifier(p_type1->enum_specifier);
@@ -1731,7 +1731,7 @@ struct type type_common(const struct type* p_type1, const struct type* p_type2, 
         promoted_a = type_dup(p_type1);
     }
 
-    if (type_is_enum(p_type2))
+    if (type_is_enum(p_type2) && !type_is_enumerator(p_type2))
     {
         _Assert(p_type2->enum_specifier);
         const struct enum_specifier* complete = get_complete_enum_specifier(p_type2->enum_specifier);

--- a/src/type.c
+++ b/src/type.c
@@ -3312,12 +3312,17 @@ bool type_is_same(const struct type* a, const struct type* b, bool compare_quali
             underlying_matched = true;
         }
 
-        if (pa->enum_specifier &&
-            pb->enum_specifier &&
-            get_complete_enum_specifier(pa->enum_specifier) !=
-            get_complete_enum_specifier(pb->enum_specifier))
+        if (pa->enum_specifier && pb->enum_specifier)
         {
-            return false;
+            const struct enum_specifier* pa_complete_enum = get_complete_enum_specifier(pa->enum_specifier);
+            const struct enum_specifier* pb_complete_enum = get_complete_enum_specifier(pb->enum_specifier);
+            if (pa_complete_enum != pb_complete_enum)
+                return false;
+
+            // both dont have enumerator list
+            // must have same tag
+            if (pa_complete_enum == NULL && pb_complete_enum == NULL && strcmp(pa->enum_specifier->tag_name, pb->enum_specifier->tag_name) != 0)
+                return false;
         }
 
 

--- a/src/type.c
+++ b/src/type.c
@@ -996,6 +996,19 @@ bool type_is_pointer(const struct type* p_type)
     return p_type->category == TYPE_CATEGORY_POINTER;
 }
 
+bool type_is_incomplete(const struct type* p_type)
+{
+    if (p_type->struct_or_union_specifier && !p_type->struct_or_union_specifier->complete_struct_or_union_specifier_indirection)
+    {
+        return true;
+    }
+    if (p_type->enum_specifier && p_type->enum_specifier->integer_type.type_specifier_flags == TYPE_SPECIFIER_NONE)
+    {
+        return true;
+    }
+    return false;
+}
+
 bool type_is_essential_bool(const struct type* p_type)
 {
     return p_type->attributes_flags & CAKE_HIDDEN_ATTRIBUTE_LIKE_BOOL;

--- a/src/type.c
+++ b/src/type.c
@@ -998,14 +998,15 @@ bool type_is_pointer(const struct type* p_type)
 
 bool type_is_incomplete(const struct type* p_type)
 {
-    if (p_type->struct_or_union_specifier && !p_type->struct_or_union_specifier->complete_struct_or_union_specifier_indirection)
+    if (p_type->enum_specifier)
     {
-        return true;
+        return get_complete_enum_specifier(p_type->enum_specifier) == NULL;
     }
-    if (p_type->enum_specifier && p_type->enum_specifier->integer_type.type_specifier_flags == TYPE_SPECIFIER_NONE)
+    if (p_type->struct_or_union_specifier)
     {
-        return true;
+        return get_complete_struct_or_union_specifier(p_type->struct_or_union_specifier) == NULL;
     }
+
     return false;
 }
 

--- a/src/type.c
+++ b/src/type.c
@@ -1000,7 +1000,7 @@ bool type_is_incomplete(const struct type* p_type)
 {
     if (p_type->enum_specifier)
     {
-        return get_complete_enum_specifier(p_type->enum_specifier) == NULL;
+        return p_type->enum_specifier->integer_type.type_specifier_flags == TYPE_SPECIFIER_NONE;
     }
     if (p_type->struct_or_union_specifier)
     {

--- a/src/type.c
+++ b/src/type.c
@@ -1000,7 +1000,7 @@ bool type_is_incomplete(const struct type* p_type)
 {
     if (p_type->enum_specifier)
     {
-        return p_type->enum_specifier->integer_type.type_specifier_flags == TYPE_SPECIFIER_NONE;
+        return get_complete_enum_specifier(p_type->enum_specifier) == NULL;
     }
     if (p_type->struct_or_union_specifier)
     {
@@ -1023,6 +1023,11 @@ bool type_is_enum(const struct type* p_type)
 {
     return type_get_category(p_type) == TYPE_CATEGORY_ITSELF &&
         p_type->type_specifier_flags & TYPE_SPECIFIER_ENUM;
+}
+
+bool type_is_enumerator(const struct type* p_type)
+{
+    return p_type->enum_specifier && p_type->type_specifier_flags != TYPE_SPECIFIER_ENUM;
 }
 
 bool type_is_struct_or_union(const struct type* p_type)
@@ -1717,7 +1722,8 @@ struct type type_common(const struct type* p_type1, const struct type* p_type2, 
     if (type_is_enum(p_type1))
     {
         _Assert(p_type1->enum_specifier);
-        promoted_a = type_dup(&p_type1->enum_specifier->integer_type);
+        const struct enum_specifier* complete = get_complete_enum_specifier(p_type1->enum_specifier);
+        promoted_a = type_dup(&complete->integer_type);
 
     }
     else
@@ -1728,7 +1734,8 @@ struct type type_common(const struct type* p_type1, const struct type* p_type2, 
     if (type_is_enum(p_type2))
     {
         _Assert(p_type2->enum_specifier);
-        promoted_b = type_dup(&p_type2->enum_specifier->integer_type);
+        const struct enum_specifier* complete = get_complete_enum_specifier(p_type2->enum_specifier);
+        promoted_b = type_dup(&complete->integer_type);
     }
     else
     {
@@ -2658,12 +2665,8 @@ size_t type_get_alignof(const struct type* p_type, enum target target)
         }
         else if (p_type->type_specifier_flags & TYPE_SPECIFIER_ENUM)
         {
-            if (p_type->enum_specifier)
-            {
-                align = type_get_alignof(&p_type->enum_specifier->integer_type, target);
-            }
-            else
-                align = get_platform(target)->int_alignment;
+            const struct enum_specifier* complete = get_complete_enum_specifier(p_type->enum_specifier);
+            align = type_get_alignof(&complete->integer_type, target);
         }
         else if (p_type->type_specifier_flags == (TYPE_SPECIFIER_LONG | TYPE_SPECIFIER_DOUBLE))
         {
@@ -2962,7 +2965,10 @@ enum sizeof_result type_get_sizeof(const struct type* p_type, size_t* size, enum
     {
         if (p_type->enum_specifier)
         {
-            enum sizeof_result e = type_get_sizeof(&p_type->enum_specifier->integer_type, size, target);
+            const struct enum_specifier* complete = get_complete_enum_specifier(p_type->enum_specifier);
+            if (complete == NULL)
+                return SIZEOF_RESULT_INCOMPLETE;
+            enum sizeof_result e = type_get_sizeof(&complete->integer_type, size, target);
             return e;
         }
         else
@@ -3089,7 +3095,8 @@ struct type type_get_enum_type(const struct type* p_type)
         if (p_type->enum_specifier == NULL)
             throw;
 
-        return type_dup(&p_type->enum_specifier->integer_type);
+        const struct enum_specifier* complete = get_complete_enum_specifier(p_type->enum_specifier);
+        return type_dup(&complete->integer_type);
     }
     catch
     {
@@ -3295,7 +3302,8 @@ bool type_is_same(const struct type* a, const struct type* b, bool compare_quali
         if (pa->type_specifier_flags == TYPE_SPECIFIER_ENUM)
         {
             _Assert(pa->enum_specifier);
-            if (!type_is_same(&pa->enum_specifier->integer_type, pb, compare_qualifiers))
+            const struct enum_specifier* complete = get_complete_enum_specifier(pa->enum_specifier);
+            if (!type_is_same(&complete->integer_type, pb, compare_qualifiers))
             {
                 return false;
             }
@@ -3305,7 +3313,8 @@ bool type_is_same(const struct type* a, const struct type* b, bool compare_quali
         if (pb->type_specifier_flags == TYPE_SPECIFIER_ENUM)
         {
             _Assert(pb->enum_specifier);
-            if (!type_is_same(pa, &pb->enum_specifier->integer_type, compare_qualifiers))
+            const struct enum_specifier* complete = get_complete_enum_specifier(pb->enum_specifier);
+            if (!type_is_same(pa, &complete->integer_type, compare_qualifiers))
             {
                 return false;
             }

--- a/src/type.h
+++ b/src/type.h
@@ -306,6 +306,8 @@ struct type type_common(const struct type* p_type1, const struct type* p_type2, 
 struct type get_array_item_type(const struct type* p_type);
 struct type type_remove_pointer(const struct type* p_type);
 
+bool type_is_incomplete(const struct type* p_type);
+
 bool type_is_essential_bool(const struct type* p_type);
 bool type_is_essential_char(const struct type* p_type);
 

--- a/src/type.h
+++ b/src/type.h
@@ -312,6 +312,7 @@ bool type_is_essential_bool(const struct type* p_type);
 bool type_is_essential_char(const struct type* p_type);
 
 bool type_is_enum(const struct type* p_type);
+bool type_is_enumerator(const struct type* p_type);
 bool type_is_array(const struct type* p_type);
 
 bool type_is_ctor(const struct type* p_type);


### PR DESCRIPTION
mimics gcc/clang behavior:
```C
enum E a; // error: incomplete enum
```
but this is ok:
```C
enum E a;

enum E { A };
```

Also fixed cake not giving diagnosis with functions defs that contain incomplete types:
```C
void foo(struct S) {}
```
the above code, cake used to error with no message, now gives:
```
error 740: function has incomplete parameter type
 1 |void foo(struct S) {}
   |     ~~~
```

however, this is allowed, as it should be:
```C
enum E : int;
void foo(enum E);
```